### PR TITLE
Add zoomable floor plan display to structure detail screen

### DIFF
--- a/build-logic/src/main/kotlin/cz/adamec/timotej/snag/buildsrc/configuration/ComposeMultiplatformModuleSetup.kt
+++ b/build-logic/src/main/kotlin/cz/adamec/timotej/snag/buildsrc/configuration/ComposeMultiplatformModuleSetup.kt
@@ -68,6 +68,7 @@ internal fun Project.configureComposeMultiplatformModule() {
                 implementation(library("koin-compose-navigation3"))
                 implementation(library("coil-compose"))
                 implementation(library("coil-network-ktor"))
+                implementation(library("zoomimage-compose-coil3"))
             }
             commonTest.dependencies {
                 implementation(library("kotlin-test"))

--- a/composeApp/src/commonMain/kotlin/cz/adamec/timotej/snag/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/cz/adamec/timotej/snag/di/AppModule.kt
@@ -13,6 +13,7 @@
 package cz.adamec.timotej.snag.di
 
 import cz.adamec.timotej.snag.feat.shared.database.fe.di.databaseModule
+import cz.adamec.timotej.snag.feat.structures.fe.driving.api.di.structuresDrivingApiModule
 import cz.adamec.timotej.snag.lib.core.fe.di.frontendCoreModule
 import cz.adamec.timotej.snag.lib.sync.fe.app.di.syncAppModule
 import cz.adamec.timotej.snag.lib.sync.fe.driven.impl.di.syncDrivenModule
@@ -22,7 +23,6 @@ import cz.adamec.timotej.snag.projects.fe.app.impl.di.projectsAppModule
 import cz.adamec.timotej.snag.projects.fe.driven.di.projectsDrivenModule
 import cz.adamec.timotej.snag.projects.fe.driving.api.di.projectsDrivingApiModule
 import cz.adamec.timotej.snag.projects.fe.driving.impl.di.projectsDrivingImplModule
-import cz.adamec.timotej.snag.feat.structures.fe.driving.api.di.structuresDrivingApiModule
 import cz.adamec.timotej.snag.structures.fe.app.impl.di.structuresAppModule
 import cz.adamec.timotej.snag.structures.fe.driven.di.structuresDrivenModule
 import cz.adamec.timotej.snag.structures.fe.driving.impl.di.structuresDrivingImplModule

--- a/feat/structures/fe/driving/impl/src/commonMain/composeResources/values/strings.xml
+++ b/feat/structures/fe/driving/impl/src/commonMain/composeResources/values/strings.xml
@@ -6,4 +6,5 @@
     <string name="structure_not_found">Structure not found</string>
     <string name="delete_structure_confirmation_title">Delete structure?</string>
     <string name="delete_structure_confirmation_text">This structure and all its data will be permanently deleted. This action cannot be undone.</string>
+    <string name="no_floor_plan">No floor plan</string>
 </resources>

--- a/feat/structures/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/internal/structureDetails/ui/StructureDetailsContent.kt
+++ b/feat/structures/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/internal/structureDetails/ui/StructureDetailsContent.kt
@@ -21,8 +21,11 @@ import androidx.compose.material3.ContainedLoadingIndicator
 import androidx.compose.material3.HorizontalFloatingToolbar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -30,9 +33,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
+import com.github.panpf.zoomimage.CoilZoomAsyncImage
 import cz.adamec.timotej.snag.lib.design.fe.scaffold.BackNavigationIcon
-import cz.adamec.timotej.snag.lib.design.fe.scaffold.CollapsableTopAppBarScaffold
 import cz.adamec.timotej.snag.structures.fe.driving.impl.internal.structureDetails.vm.StructureDetailsUiState
 import cz.adamec.timotej.snag.structures.fe.driving.impl.internal.structureDetails.vm.StructureDetailsUiStatus
 import org.jetbrains.compose.resources.painterResource
@@ -40,6 +44,7 @@ import org.jetbrains.compose.resources.stringResource
 import snag.feat.structures.fe.driving.impl.generated.resources.Res
 import snag.feat.structures.fe.driving.impl.generated.resources.delete_structure_confirmation_text
 import snag.feat.structures.fe.driving.impl.generated.resources.delete_structure_confirmation_title
+import snag.feat.structures.fe.driving.impl.generated.resources.no_floor_plan
 import snag.feat.structures.fe.driving.impl.generated.resources.structure_not_found
 import snag.lib.design.fe.generated.resources.delete
 import snag.lib.design.fe.generated.resources.ic_delete
@@ -71,7 +76,7 @@ internal fun StructureDetailsContent(
 
             StructureDetailsUiStatus.LOADED,
             StructureDetailsUiStatus.DELETED,
-                -> {
+            -> {
                 LoadedStructureDetailsContent(
                     state = state,
                     onBack = onBack,
@@ -93,12 +98,18 @@ private fun LoadedStructureDetailsContent(
     onDelete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    CollapsableTopAppBarScaffold(
+    Scaffold(
         modifier = modifier,
-        title = state.structure?.name.orEmpty(),
-        topAppBarNavigationIcon = {
-            BackNavigationIcon(
-                onClick = onBack,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(text = state.structure?.name.orEmpty())
+                },
+                navigationIcon = {
+                    BackNavigationIcon(
+                        onClick = onBack,
+                    )
+                },
             )
         },
     ) { paddingValues ->
@@ -109,6 +120,20 @@ private fun LoadedStructureDetailsContent(
                     .padding(paddingValues)
                     .consumeWindowInsets(paddingValues),
         ) {
+            val floorPlanUrl = state.structure?.floorPlanUrl
+            if (floorPlanUrl != null) {
+                CoilZoomAsyncImage(
+                    model = floorPlanUrl,
+                    contentDescription = state.structure?.name,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Fit,
+                )
+            } else {
+                FloorPlanPlaceholder(
+                    modifier = Modifier.align(Alignment.Center),
+                )
+            }
+
             var isShowingDeleteConfirmation by remember { mutableStateOf(false) }
             if (isShowingDeleteConfirmation) {
                 StructureDeletionAlertDialog(
@@ -140,6 +165,16 @@ private fun LoadedStructureDetailsContent(
             }
         }
     }
+}
+
+@Composable
+private fun FloorPlanPlaceholder(modifier: Modifier = Modifier) {
+    Text(
+        modifier = modifier,
+        text = stringResource(Res.string.no_floor_plan),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
 }
 
 @Composable

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ kotlinx-immmutable-collections = "0.4.0"
 koin = "4.2.0-RC1"
 koinKspCompiler = "2.3.1"
 coil = "3.3.0"
+zoomimage = "1.4.0"
 kermit = "2.0.8"
 ktor = "3.4.0"
 slf4j = "2.0.17"
@@ -75,6 +76,8 @@ koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
 
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-network-ktor = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
+
+zoomimage-compose-coil3 = { module = "io.github.panpf.zoomimage:zoomimage-compose-coil3", version.ref = "zoomimage" }
 
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 kermit-koin = { module = "co.touchlab:kermit-koin", version.ref = "kermit" }


### PR DESCRIPTION
## Summary
- Integrate `zoomimage-compose-coil3` (v1.4.0) for zoomable, pannable floor plan display in the structure detail screen
- Replace collapsible top app bar with fixed `TopAppBar` to avoid gesture conflicts between app bar collapse and image pan
- Show a text placeholder when no floor plan URL is available
- Fix pre-existing ktlint import ordering issue in `AppModule.kt`

## Test plan
- [ ] Open a structure with a `floorPlanUrl` — verify the floor plan image loads and fills the screen
- [ ] Pinch-to-zoom and pan the image — verify gestures work smoothly
- [ ] Double-tap to zoom in/out — verify it works
- [ ] Open a structure without a `floorPlanUrl` — verify "No floor plan" placeholder is shown
- [ ] Tap the delete button — verify the deletion flow still works correctly
- [ ] Run `./gradlew :feat:structures:fe:driving:impl:jvmTest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)