### PR TITLE
Add edit button to project details

### DIFF
--- a/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/di/ProjectsDrivingModule.kt
+++ b/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/di/ProjectsDrivingModule.kt
@@ -24,6 +24,7 @@ import cz.adamec.timotej.snag.projects.fe.driving.api.ProjectCreationRoute
 import cz.adamec.timotej.snag.projects.fe.driving.api.ProjectDetailRoute
 import cz.adamec.timotej.snag.projects.fe.driving.api.ProjectDetailRouteFactory
 import cz.adamec.timotej.snag.projects.fe.driving.api.ProjectEditRoute
+import cz.adamec.timotej.snag.projects.fe.driving.api.ProjectEditRouteFactory
 import cz.adamec.timotej.snag.projects.fe.driving.api.ProjectsRoute
 import cz.adamec.timotej.snag.projects.fe.driving.impl.internal.projectDetails.ui.ProjectDetailsScreen
 import cz.adamec.timotej.snag.projects.fe.driving.impl.internal.projectDetails.vm.ProjectDetailsViewModel
@@ -78,8 +79,9 @@ internal inline fun <reified T : ProjectCreationRoute> Module.projectCreationScr
 internal inline fun <reified T : ProjectEditRoute> Module.projectEditScreenNavigation() =
     navigation<T>(
         metadata = DialogSceneStrategy.dialog(DialogProperties(usePlatformDefaultWidth = false)),
-    ) { _ ->
+    ) { route ->
         ProjectDetailsEditScreenInjection(
+            projectId = route.projectId,
             onSaveProject = { _ ->
                 val backStack = get<SnagBackStack>()
                 backStack.removeLastSafely()
@@ -89,9 +91,11 @@ internal inline fun <reified T : ProjectEditRoute> Module.projectEditScreenNavig
 
 @Composable
 private fun Scope.ProjectDetailsEditScreenInjection(
+    projectId: Uuid? = null,
     onSaveProject: (savedProjectId: Uuid) -> Unit,
 ) {
     ProjectDetailsEditScreen(
+        projectId = projectId,
         onSaveProject = { savedProjectId ->
             onSaveProject(savedProjectId)
         },
@@ -106,6 +110,7 @@ internal inline fun <reified T : ProjectDetailRoute> Module.projectDetailsScreen
     navigation<T> { route ->
         val newStructureRouteFactory = koinInject<StructureCreationRouteFactory>()
         val structureDetailRouteFactory = koinInject<StructureDetailRouteFactory>()
+        val projectEditRouteFactory = koinInject<ProjectEditRouteFactory>()
         ProjectDetailsScreen(
             projectId = route.projectId,
             onNewStructureClick = {
@@ -119,6 +124,10 @@ internal inline fun <reified T : ProjectDetailRoute> Module.projectDetailsScreen
             onBack = {
                 val backStack = get<SnagBackStack>()
                 backStack.removeLastSafely()
+            },
+            onEditClick = {
+                val backStack = get<SnagBackStack>()
+                backStack.value.add(projectEditRouteFactory.create(route.projectId))
             },
         )
     }

--- a/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetails/ui/ProjectDetailsContent.kt
+++ b/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetails/ui/ProjectDetailsContent.kt
@@ -65,8 +65,10 @@ import snag.feat.projects.fe.driving.impl.generated.resources.new_project
 import snag.feat.projects.fe.driving.impl.generated.resources.new_structure
 import snag.feat.projects.fe.driving.impl.generated.resources.project_not_found
 import snag.lib.design.fe.generated.resources.delete
+import snag.lib.design.fe.generated.resources.edit
 import snag.lib.design.fe.generated.resources.ic_add
 import snag.lib.design.fe.generated.resources.ic_delete
+import snag.lib.design.fe.generated.resources.ic_edit
 import snag.lib.design.fe.generated.resources.Res as DesignRes
 
 @Composable
@@ -75,6 +77,7 @@ internal fun ProjectDetailsContent(
     onNewStructureClick: () -> Unit,
     onStructureClick: (structureId: Uuid) -> Unit,
     onBack: () -> Unit,
+    onEditClick: () -> Unit,
     onDelete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -103,6 +106,7 @@ internal fun ProjectDetailsContent(
                     onNewStructureClick = onNewStructureClick,
                     onStructureClick = onStructureClick,
                     onBack = onBack,
+                    onEditClick = onEditClick,
                     onDelete = onDelete,
                 )
 
@@ -117,6 +121,7 @@ private fun LoadedProjectDetailsContent(
     onNewStructureClick: () -> Unit,
     onStructureClick: (structureId: Uuid) -> Unit,
     onBack: () -> Unit,
+    onEditClick: () -> Unit,
     onDelete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -211,6 +216,14 @@ private fun LoadedProjectDetailsContent(
                 expanded = true,
             ) {
                 IconButton(
+                    onClick = onEditClick,
+                ) {
+                    Icon(
+                        painter = painterResource(DesignRes.drawable.ic_edit),
+                        contentDescription = stringResource(DesignRes.string.edit),
+                    )
+                }
+                IconButton(
                     enabled = state.canInvokeDeletion,
                     onClick = {
                         isShowingDeleteConfirmation = true
@@ -279,6 +292,7 @@ private fun LoadedProjectDetailsContentPreview() {
             onNewStructureClick = {},
             onStructureClick = {},
             onBack = {},
+            onEditClick = {},
             onDelete = {},
         )
     }

--- a/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetails/ui/ProjectDetailsScreen.kt
+++ b/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetails/ui/ProjectDetailsScreen.kt
@@ -28,6 +28,7 @@ internal fun ProjectDetailsScreen(
     onNewStructureClick: () -> Unit,
     onStructureClick: (structureId: Uuid) -> Unit,
     onBack: () -> Unit,
+    onEditClick: () -> Unit,
     viewModel: ProjectDetailsViewModel = koinViewModel { parametersOf(projectId) },
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -47,6 +48,7 @@ internal fun ProjectDetailsScreen(
         onNewStructureClick = onNewStructureClick,
         onStructureClick = onStructureClick,
         onBack = onBack,
+        onEditClick = onEditClick,
         onDelete = viewModel::onDelete,
     )
 }

--- a/lib/design/fe/src/commonMain/composeResources/drawable/ic_edit.xml
+++ b/lib/design/fe/src/commonMain/composeResources/drawable/ic_edit.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M200,760h57l391,-391 -57,-57 -391,391v57ZM120,840v-170l527,-526q12,-12 27,-18t30,-6q16,0 30.5,6t25.5,18l56,56q12,11 18,25.5t6,30.5q0,15 -6,30t-18,27L310,840L120,840ZM760,282l-56,-56 56,56ZM648,394l-29,-28 57,57 -28,-29Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/lib/design/fe/src/commonMain/composeResources/values/strings.xml
+++ b/lib/design/fe/src/commonMain/composeResources/values/strings.xml
@@ -17,4 +17,5 @@
     <string name="save">Save</string>
     <string name="back">Back</string>
     <string name="delete">Delete</string>
+    <string name="edit">Edit</string>
 </resources>


### PR DESCRIPTION
## Summary
- Add an edit icon button to the project details floating toolbar (next to delete)
- Wire navigation from project details to the existing edit dialog, passing `projectId` so the form is pre-filled
- Fix `projectEditScreenNavigation` to forward `route.projectId` to the edit screen (was previously ignored)
- Add `ic_edit` drawable and `edit` string resource to the design library

## Test plan
- [ ] Navigate to a project detail screen and verify the edit icon appears in the bottom floating toolbar
- [ ] Tap the edit icon and verify the edit dialog opens pre-filled with the project's name and address
- [ ] Edit a field, save, and verify the dialog closes and the detail screen reflects the updated data
- [ ] Verify the delete button still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)