### PR TITLE
Fix web SQLDelight async driver crash in finding updates

### DIFF
--- a/feat/findings/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driven/internal/db/RealFindingsDb.kt
+++ b/feat/findings/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driven/internal/db/RealFindingsDb.kt
@@ -12,6 +12,7 @@
 
 package cz.adamec.timotej.snag.findings.fe.driven.internal.db
 
+import app.cash.sqldelight.async.coroutines.awaitAsOne
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import app.cash.sqldelight.coroutines.mapToOneOrNull
@@ -130,7 +131,7 @@ internal class RealFindingsDb(
             runCatching {
                 findingEntityQueries.transactionWithResult {
                     findingEntityQueries.updateDetails(name = name, description = description, id = id.toString())
-                    findingEntityQueries.selectChanges().executeAsOne()
+                    findingEntityQueries.selectChanges().awaitAsOne()
                 }
             }.fold(
                 onSuccess = { changes ->
@@ -158,7 +159,7 @@ internal class RealFindingsDb(
                         coordinates = serializeCoordinates(coordinates),
                         id = id.toString(),
                     )
-                    findingEntityQueries.selectChanges().executeAsOne()
+                    findingEntityQueries.selectChanges().awaitAsOne()
                 }
             }.fold(
                 onSuccess = { changes ->


### PR DESCRIPTION
## Summary
- Replace synchronous `transactionWithResult`/`executeAsOne()` with `awaitAsOne()` in `RealFindingsDb` for `updateFindingDetails` and `updateFindingCoordinates`
- The web target uses an async SQLDelight driver (`createDefaultWebWorkerDriver`), which throws `IllegalStateException` when synchronous query result access (`.value`) is attempted
- Uses `awaitAsOne()` from `app.cash.sqldelight.async.coroutines` to properly suspend and await async query results

## Test plan
- [ ] Run web (JS/Wasm) target and update a finding's details — verify no `IllegalStateException`
- [ ] Run web target and update a finding's coordinates — verify no crash
- [ ] Verify desktop/Android/iOS targets still work (they use synchronous drivers unaffected by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)