### PR TITLE
Migrate backend tests to use BackendKoinInitializedTest base class

### DIFF
--- a/feat/findings/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/findings/be/app/impl/internal/GetFindingsModifiedSinceUseCaseImplTest.kt
+++ b/feat/findings/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/findings/be/app/impl/internal/GetFindingsModifiedSinceUseCaseImplTest.kt
@@ -19,7 +19,6 @@ import cz.adamec.timotej.snag.findings.be.driven.test.FakeFindingsLocalDataSourc
 import cz.adamec.timotej.snag.findings.be.ports.FindingsLocalDataSource
 import cz.adamec.timotej.snag.lib.core.common.Timestamp
 import cz.adamec.timotej.snag.testinfra.be.BackendKoinInitializedTest
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
@@ -31,7 +30,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class GetFindingsModifiedSinceUseCaseImplTest : BackendKoinInitializedTest() {
     private val dataSource: FakeFindingsLocalDataSource by inject()
     private val useCase: GetFindingsModifiedSinceUseCase by inject()

--- a/feat/projects/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/projects/be/app/impl/internal/DeleteProjectUseCaseImplTest.kt
+++ b/feat/projects/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/projects/be/app/impl/internal/DeleteProjectUseCaseImplTest.kt
@@ -20,7 +20,6 @@ import cz.adamec.timotej.snag.projects.be.model.BackendProject
 import cz.adamec.timotej.snag.projects.be.ports.ProjectsLocalDataSource
 import cz.adamec.timotej.snag.projects.business.Project
 import cz.adamec.timotej.snag.testinfra.be.BackendKoinInitializedTest
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
@@ -33,7 +32,6 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class DeleteProjectUseCaseImplTest : BackendKoinInitializedTest() {
     private val dataSource: FakeProjectsLocalDataSource by inject()
     private val useCase: DeleteProjectUseCase by inject()

--- a/feat/projects/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/projects/be/app/impl/internal/GetProjectUseCaseImplTest.kt
+++ b/feat/projects/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/projects/be/app/impl/internal/GetProjectUseCaseImplTest.kt
@@ -19,7 +19,6 @@ import cz.adamec.timotej.snag.projects.be.model.BackendProject
 import cz.adamec.timotej.snag.projects.be.ports.ProjectsLocalDataSource
 import cz.adamec.timotej.snag.projects.business.Project
 import cz.adamec.timotej.snag.testinfra.be.BackendKoinInitializedTest
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
@@ -31,7 +30,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class GetProjectUseCaseImplTest : BackendKoinInitializedTest() {
     private val dataSource: FakeProjectsLocalDataSource by inject()
     private val useCase: GetProjectUseCase by inject()

--- a/feat/projects/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/projects/be/app/impl/internal/GetProjectsModifiedSinceUseCaseImplTest.kt
+++ b/feat/projects/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/projects/be/app/impl/internal/GetProjectsModifiedSinceUseCaseImplTest.kt
@@ -19,7 +19,6 @@ import cz.adamec.timotej.snag.projects.be.model.BackendProject
 import cz.adamec.timotej.snag.projects.be.ports.ProjectsLocalDataSource
 import cz.adamec.timotej.snag.projects.business.Project
 import cz.adamec.timotej.snag.testinfra.be.BackendKoinInitializedTest
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
@@ -31,7 +30,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class GetProjectsModifiedSinceUseCaseImplTest : BackendKoinInitializedTest() {
     private val dataSource: FakeProjectsLocalDataSource by inject()
     private val useCase: GetProjectsModifiedSinceUseCase by inject()

--- a/feat/projects/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/projects/be/app/impl/internal/GetProjectsUseCaseImplTest.kt
+++ b/feat/projects/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/projects/be/app/impl/internal/GetProjectsUseCaseImplTest.kt
@@ -19,7 +19,6 @@ import cz.adamec.timotej.snag.projects.be.model.BackendProject
 import cz.adamec.timotej.snag.projects.be.ports.ProjectsLocalDataSource
 import cz.adamec.timotej.snag.projects.business.Project
 import cz.adamec.timotej.snag.testinfra.be.BackendKoinInitializedTest
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
@@ -30,7 +29,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class GetProjectsUseCaseImplTest : BackendKoinInitializedTest() {
     private val dataSource: FakeProjectsLocalDataSource by inject()
     private val useCase: GetProjectsUseCase by inject()

--- a/feat/projects/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/projects/be/app/impl/internal/SaveProjectUseCaseImplTest.kt
+++ b/feat/projects/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/projects/be/app/impl/internal/SaveProjectUseCaseImplTest.kt
@@ -19,7 +19,6 @@ import cz.adamec.timotej.snag.projects.be.model.BackendProject
 import cz.adamec.timotej.snag.projects.be.ports.ProjectsLocalDataSource
 import cz.adamec.timotej.snag.projects.business.Project
 import cz.adamec.timotej.snag.testinfra.be.BackendKoinInitializedTest
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
@@ -32,7 +31,6 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class SaveProjectUseCaseImplTest : BackendKoinInitializedTest() {
     private val dataSource: FakeProjectsLocalDataSource by inject()
     private val useCase: SaveProjectUseCase by inject()

--- a/feat/structures/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/structures/be/app/impl/internal/DeleteStructureUseCaseImplTest.kt
+++ b/feat/structures/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/structures/be/app/impl/internal/DeleteStructureUseCaseImplTest.kt
@@ -20,7 +20,6 @@ import cz.adamec.timotej.snag.structures.be.app.api.model.DeleteStructureRequest
 import cz.adamec.timotej.snag.structures.be.driven.test.FakeStructuresLocalDataSource
 import cz.adamec.timotej.snag.structures.be.ports.StructuresLocalDataSource
 import cz.adamec.timotej.snag.testinfra.be.BackendKoinInitializedTest
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
@@ -33,7 +32,6 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class DeleteStructureUseCaseImplTest : BackendKoinInitializedTest() {
     private val dataSource: FakeStructuresLocalDataSource by inject()
     private val useCase: DeleteStructureUseCase by inject()

--- a/feat/structures/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/structures/be/app/impl/internal/GetStructuresModifiedSinceUseCaseImplTest.kt
+++ b/feat/structures/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/structures/be/app/impl/internal/GetStructuresModifiedSinceUseCaseImplTest.kt
@@ -19,7 +19,6 @@ import cz.adamec.timotej.snag.structures.be.app.api.GetStructuresModifiedSinceUs
 import cz.adamec.timotej.snag.structures.be.driven.test.FakeStructuresLocalDataSource
 import cz.adamec.timotej.snag.structures.be.ports.StructuresLocalDataSource
 import cz.adamec.timotej.snag.testinfra.be.BackendKoinInitializedTest
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
@@ -31,7 +30,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class GetStructuresModifiedSinceUseCaseImplTest : BackendKoinInitializedTest() {
     private val dataSource: FakeStructuresLocalDataSource by inject()
     private val useCase: GetStructuresModifiedSinceUseCase by inject()

--- a/feat/structures/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/structures/be/app/impl/internal/GetStructuresUseCaseImplTest.kt
+++ b/feat/structures/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/structures/be/app/impl/internal/GetStructuresUseCaseImplTest.kt
@@ -19,7 +19,6 @@ import cz.adamec.timotej.snag.structures.be.app.api.GetStructuresUseCase
 import cz.adamec.timotej.snag.structures.be.driven.test.FakeStructuresLocalDataSource
 import cz.adamec.timotej.snag.structures.be.ports.StructuresLocalDataSource
 import cz.adamec.timotej.snag.testinfra.be.BackendKoinInitializedTest
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
@@ -30,7 +29,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class GetStructuresUseCaseImplTest : BackendKoinInitializedTest() {
     private val dataSource: FakeStructuresLocalDataSource by inject()
     private val useCase: GetStructuresUseCase by inject()

--- a/feat/structures/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/structures/be/app/impl/internal/SaveStructureUseCaseImplTest.kt
+++ b/feat/structures/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/structures/be/app/impl/internal/SaveStructureUseCaseImplTest.kt
@@ -19,7 +19,6 @@ import cz.adamec.timotej.snag.structures.be.app.api.SaveStructureUseCase
 import cz.adamec.timotej.snag.structures.be.driven.test.FakeStructuresLocalDataSource
 import cz.adamec.timotej.snag.structures.be.ports.StructuresLocalDataSource
 import cz.adamec.timotej.snag.testinfra.be.BackendKoinInitializedTest
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
@@ -31,7 +30,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class SaveStructureUseCaseImplTest : BackendKoinInitializedTest() {
     private val dataSource: FakeStructuresLocalDataSource by inject()
     private val useCase: SaveStructureUseCase by inject()


### PR DESCRIPTION
Replace direct instantiation of use case implementations and fake data
sources with Koin dependency injection, matching the frontend test
pattern using FrontendKoinInitializedTest. Tests now extend
BackendKoinInitializedTest and use `by inject()` for dependencies,
with fake data sources bound via `additionalKoinModules()`.

https://claude.ai/code/session_01KmUejBzryMvko41QxdxKZw