### PR TITLE
Replace JSON string coordinates with dedicated DB table

### DIFF
--- a/feat/findings/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driven/di/FindingsDrivenModule.kt
+++ b/feat/findings/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driven/di/FindingsDrivenModule.kt
@@ -34,6 +34,7 @@ val findingsDrivenModule =
         factory {
             RealFindingsDb(
                 findingEntityQueries = get(),
+                findingCoordinateEntityQueries = get(),
                 ioDispatcher = getIoDispatcher(),
             )
         } bind FindingsDb::class

--- a/feat/shared/database/fe/src/commonMain/kotlin/cz/adamec/timotej/snag/feat/shared/database/fe/di/DatabaseModule.kt
+++ b/feat/shared/database/fe/src/commonMain/kotlin/cz/adamec/timotej/snag/feat/shared/database/fe/di/DatabaseModule.kt
@@ -13,6 +13,7 @@
 package cz.adamec.timotej.snag.feat.shared.database.fe.di
 
 import app.cash.sqldelight.db.SqlDriver
+import cz.adamec.timotej.snag.feat.shared.database.fe.db.FindingCoordinateEntityQueries
 import cz.adamec.timotej.snag.feat.shared.database.fe.db.FindingEntityQueries
 import cz.adamec.timotej.snag.feat.shared.database.fe.db.ProjectEntityQueries
 import cz.adamec.timotej.snag.feat.shared.database.fe.db.PullSyncTimestampEntityQueries
@@ -53,6 +54,11 @@ val databaseModule =
             val snagDatabase = get<SnagDatabase>()
             snagDatabase.findingEntityQueries
         } bind FindingEntityQueries::class
+
+        factory {
+            val snagDatabase = get<SnagDatabase>()
+            snagDatabase.findingCoordinateEntityQueries
+        } bind FindingCoordinateEntityQueries::class
 
         factory {
             val snagDatabase = get<SnagDatabase>()

--- a/feat/shared/database/fe/src/commonMain/sqldelight/cz/adamec/timotej/snag/feat/shared/database/fe/db/1.sqm
+++ b/feat/shared/database/fe/src/commonMain/sqldelight/cz/adamec/timotej/snag/feat/shared/database/fe/db/1.sqm
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS FindingCoordinateEntity (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    findingId TEXT NOT NULL,
+    x REAL NOT NULL,
+    y REAL NOT NULL,
+    FOREIGN KEY (findingId) REFERENCES FindingEntity(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS FindingEntity_new (
+    id TEXT NOT NULL PRIMARY KEY,
+    structureId TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    updatedAt INTEGER NOT NULL
+);
+
+INSERT INTO FindingEntity_new (id, structureId, name, description, updatedAt)
+SELECT id, structureId, name, description, updatedAt FROM FindingEntity;
+
+DROP TABLE FindingEntity;
+
+ALTER TABLE FindingEntity_new RENAME TO FindingEntity;

--- a/feat/shared/database/fe/src/commonMain/sqldelight/cz/adamec/timotej/snag/feat/shared/database/fe/db/FindingCoordinateEntity.sq
+++ b/feat/shared/database/fe/src/commonMain/sqldelight/cz/adamec/timotej/snag/feat/shared/database/fe/db/FindingCoordinateEntity.sq
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS FindingCoordinateEntity (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    findingId TEXT NOT NULL,
+    x REAL NOT NULL,
+    y REAL NOT NULL,
+    FOREIGN KEY (findingId) REFERENCES FindingEntity(id) ON DELETE CASCADE
+);
+
+insert:
+INSERT INTO FindingCoordinateEntity(findingId, x, y) VALUES (:findingId, :x, :y);
+
+deleteByFindingId:
+DELETE FROM FindingCoordinateEntity WHERE findingId = :findingId;
+
+deleteByStructureId:
+DELETE FROM FindingCoordinateEntity WHERE findingId IN (
+    SELECT id FROM FindingEntity WHERE structureId = :structureId
+);
+
+deleteAll:
+DELETE FROM FindingCoordinateEntity;

--- a/feat/shared/database/fe/src/commonMain/sqldelight/cz/adamec/timotej/snag/feat/shared/database/fe/db/FindingEntity.sq
+++ b/feat/shared/database/fe/src/commonMain/sqldelight/cz/adamec/timotej/snag/feat/shared/database/fe/db/FindingEntity.sq
@@ -3,25 +3,29 @@ CREATE TABLE IF NOT EXISTS FindingEntity (
     structureId TEXT NOT NULL,
     name TEXT NOT NULL,
     description TEXT,
-    coordinates TEXT NOT NULL DEFAULT '[]',
     updatedAt INTEGER NOT NULL
 );
 
 save:
-INSERT INTO FindingEntity(id, structureId, name, description, coordinates, updatedAt)
+INSERT INTO FindingEntity(id, structureId, name, description, updatedAt)
 VALUES ?
 ON CONFLICT(id) DO UPDATE SET
     structureId = excluded.structureId,
     name = excluded.name,
     description = excluded.description,
-    coordinates = excluded.coordinates,
     updatedAt = excluded.updatedAt;
 
 selectByStructureId:
-SELECT * FROM FindingEntity WHERE structureId = :structureId;
+SELECT f.id, f.structureId, f.name, f.description, f.updatedAt, c.x, c.y
+FROM FindingEntity f
+LEFT JOIN FindingCoordinateEntity c ON f.id = c.findingId
+WHERE f.structureId = :structureId;
 
 selectById:
-SELECT * FROM FindingEntity WHERE id = :id;
+SELECT f.id, f.structureId, f.name, f.description, f.updatedAt, c.x, c.y
+FROM FindingEntity f
+LEFT JOIN FindingCoordinateEntity c ON f.id = c.findingId
+WHERE f.id = :id;
 
 deleteById:
 DELETE FROM FindingEntity WHERE id = :id;
@@ -35,8 +39,8 @@ DELETE FROM FindingEntity;
 updateDetails:
 UPDATE FindingEntity SET name = :name, description = :description, updatedAt = :updatedAt WHERE id = :id;
 
-updateCoordinates:
-UPDATE FindingEntity SET coordinates = :coordinates, updatedAt = :updatedAt WHERE id = :id;
+updateTimestamp:
+UPDATE FindingEntity SET updatedAt = :updatedAt WHERE id = :id;
 
 selectChanges:
 SELECT changes();


### PR DESCRIPTION
Extract finding coordinates from a serialized JSON TEXT column into a
separate FindingCoordinateEntity table with proper REAL columns for x/y
values. Select queries now use LEFT JOIN to fetch coordinates alongside
findings, and all write operations handle both tables transactionally.

Closes #12

https://claude.ai/code/session_01WMx6Hv8Yb1m3zPV6t72A9K