### PR TITLE
Make floor plan pins clickable to open finding detail

### DIFF
--- a/feat/structures/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/di/StructuresDrivingModule.kt
+++ b/feat/structures/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/di/StructuresDrivingModule.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.window.DialogProperties
 import androidx.navigation3.scene.DialogSceneStrategy
 import cz.adamec.timotej.snag.feat.findings.fe.driving.api.FindingDetailRoute
+import cz.adamec.timotej.snag.feat.findings.fe.driving.api.FindingDetailRouteFactory
 import cz.adamec.timotej.snag.feat.structures.fe.driving.api.StructureCreationRoute
 import cz.adamec.timotej.snag.feat.structures.fe.driving.api.StructureDetailBackStack
 import cz.adamec.timotej.snag.feat.structures.fe.driving.api.StructureDetailNavRoute
@@ -88,6 +89,18 @@ internal inline fun <reified T : StructureFloorPlanRoute> Module.structureFloorP
             onEditClick = {
                 val rootBackStack = get<SnagBackStack>()
                 rootBackStack.value.add(structureEditRouteFactory.create(route.structureId))
+            },
+            onFindingClick = { findingId ->
+                val factory = get<FindingDetailRouteFactory>()
+                if (structureDetailBackStack.value.lastOrNull() is FindingDetailRoute) {
+                    structureDetailBackStack.removeLastSafely()
+                }
+                structureDetailBackStack.value.add(
+                    factory.create(
+                        structureId = route.structureId,
+                        findingId = findingId,
+                    ),
+                )
             },
         )
     }

--- a/feat/structures/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/internal/floorPlan/ui/StructureFloorPlanContent.kt
+++ b/feat/structures/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/internal/floorPlan/ui/StructureFloorPlanContent.kt
@@ -45,6 +45,7 @@ import snag.lib.design.fe.generated.resources.delete
 import snag.lib.design.fe.generated.resources.edit
 import snag.lib.design.fe.generated.resources.ic_delete
 import snag.lib.design.fe.generated.resources.ic_edit
+import kotlin.uuid.Uuid
 import snag.lib.design.fe.generated.resources.Res as DesignRes
 
 @Composable
@@ -53,6 +54,7 @@ internal fun StructureFloorPlanContent(
     onBack: () -> Unit,
     onEditClick: () -> Unit,
     onDelete: () -> Unit,
+    onFindingClick: (Uuid) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -80,6 +82,7 @@ internal fun StructureFloorPlanContent(
                     onBack = onBack,
                     onEditClick = onEditClick,
                     onDelete = onDelete,
+                    onFindingClick = onFindingClick,
                 )
             }
 
@@ -96,6 +99,7 @@ private fun LoadedStructureDetailsContent(
     onBack: () -> Unit,
     onEditClick: () -> Unit,
     onDelete: () -> Unit,
+    onFindingClick: (Uuid) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -128,6 +132,7 @@ private fun LoadedStructureDetailsContent(
                     contentDescription = state.feStructure.structure.name,
                     findings = state.findings,
                     selectedFindingId = state.selectedFindingId,
+                    onFindingClick = onFindingClick,
                 )
             } else {
                 FloorPlanPlaceholder(

--- a/feat/structures/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/internal/floorPlan/ui/StructureFloorPlanScreen.kt
+++ b/feat/structures/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/internal/floorPlan/ui/StructureFloorPlanScreen.kt
@@ -29,6 +29,7 @@ internal fun StructureFloorPlanScreen(
     selectedFindingId: Uuid?,
     onBack: () -> Unit,
     onEditClick: () -> Unit,
+    onFindingClick: (Uuid) -> Unit,
     viewModel: StructureFloorPlanViewModel = koinViewModel {
         parametersOf(structureId)
     },
@@ -54,5 +55,6 @@ internal fun StructureFloorPlanScreen(
         onBack = onBack,
         onEditClick = onEditClick,
         onDelete = viewModel::onDelete,
+        onFindingClick = onFindingClick,
     )
 }


### PR DESCRIPTION
## Summary
- Floor plan pins are now tappable — clicking a pin opens the finding detail, same as clicking a finding in the list panel
- All pins are now always visible on the floor plan (previously non-selected pins were hidden when a finding was selected); selected pin remains visually distinct (tertiary color, larger radius)
- Uses `CoilZoomAsyncImage`'s built-in `onTap` callback with closest-pin hit-testing (24dp touch target), so zoom/pan/double-tap gestures are unaffected

## Test plan
- [ ] Open a structure with findings on the floor plan
- [ ] Tap a pin — verify finding detail opens
- [ ] Tap a different pin — verify the detail switches to the new finding
- [ ] Verify zoom, pan, and double-tap still work correctly
- [ ] Verify all pins remain visible when a finding is selected (selected pin highlighted, others dimmed)
- [ ] Tap empty area of the floor plan — verify nothing happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)