### PR TITLE
Add cascade delete to frontend delete use cases

### DIFF
--- a/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/DeleteProjectUseCaseImpl.kt
+++ b/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/DeleteProjectUseCaseImpl.kt
@@ -18,14 +18,17 @@ import cz.adamec.timotej.snag.projects.fe.app.api.DeleteProjectUseCase
 import cz.adamec.timotej.snag.projects.fe.app.impl.internal.LH.logger
 import cz.adamec.timotej.snag.projects.fe.ports.ProjectsDb
 import cz.adamec.timotej.snag.projects.fe.ports.ProjectsSync
+import cz.adamec.timotej.snag.structures.fe.app.api.CascadeDeleteLocalStructuresByProjectIdUseCase
 import kotlin.uuid.Uuid
 
 class DeleteProjectUseCaseImpl(
     private val projectsDb: ProjectsDb,
     private val projectsSync: ProjectsSync,
+    private val cascadeDeleteLocalStructuresByProjectIdUseCase: CascadeDeleteLocalStructuresByProjectIdUseCase,
 ) : DeleteProjectUseCase {
-    override suspend operator fun invoke(projectId: Uuid): OfflineFirstDataResult<Unit> =
-        projectsDb
+    override suspend operator fun invoke(projectId: Uuid): OfflineFirstDataResult<Unit> {
+        cascadeDeleteLocalStructuresByProjectIdUseCase(projectId)
+        return projectsDb
             .deleteProject(projectId)
             .also {
                 logger.log(
@@ -36,4 +39,5 @@ class DeleteProjectUseCaseImpl(
                     projectsSync.enqueueProjectDelete(projectId)
                 }
             }
+    }
 }

--- a/feat/projects/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/DeleteProjectUseCaseImplTest.kt
+++ b/feat/projects/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/DeleteProjectUseCaseImplTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.projects.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.feat.structures.business.Structure
+import cz.adamec.timotej.snag.feat.structures.fe.model.FrontendStructure
+import cz.adamec.timotej.snag.findings.fe.driven.test.FakeFindingsDb
+import cz.adamec.timotej.snag.findings.fe.ports.FindingsDb
+import cz.adamec.timotej.snag.lib.core.common.Timestamp
+import cz.adamec.timotej.snag.lib.core.fe.OfflineFirstDataResult
+import cz.adamec.timotej.snag.projects.business.Project
+import cz.adamec.timotej.snag.projects.fe.app.api.DeleteProjectUseCase
+import cz.adamec.timotej.snag.projects.fe.driven.test.FakeProjectsDb
+import cz.adamec.timotej.snag.projects.fe.driven.test.FakeProjectsSync
+import cz.adamec.timotej.snag.projects.fe.model.FrontendProject
+import cz.adamec.timotej.snag.projects.fe.ports.ProjectsDb
+import cz.adamec.timotej.snag.projects.fe.ports.ProjectsSync
+import cz.adamec.timotej.snag.structures.fe.driven.test.FakeStructuresDb
+import cz.adamec.timotej.snag.structures.fe.driven.test.FakeStructuresPullSyncCoordinator
+import cz.adamec.timotej.snag.structures.fe.driven.test.FakeStructuresPullSyncTimestampDataSource
+import cz.adamec.timotej.snag.structures.fe.driven.test.FakeStructuresSync
+import cz.adamec.timotej.snag.structures.fe.ports.StructuresDb
+import cz.adamec.timotej.snag.structures.fe.ports.StructuresPullSyncCoordinator
+import cz.adamec.timotej.snag.structures.fe.ports.StructuresPullSyncTimestampDataSource
+import cz.adamec.timotej.snag.structures.fe.ports.StructuresSync
+import cz.adamec.timotej.snag.testinfra.fe.FrontendKoinInitializedTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+import org.koin.test.inject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+class DeleteProjectUseCaseImplTest : FrontendKoinInitializedTest() {
+
+    private val fakeProjectsDb: FakeProjectsDb by inject()
+    private val fakeProjectsSync: FakeProjectsSync by inject()
+    private val fakeStructuresDb: FakeStructuresDb by inject()
+
+    private val useCase: DeleteProjectUseCase by inject()
+
+    override fun additionalKoinModules(): List<Module> =
+        listOf(
+            module {
+                singleOf(::FakeProjectsDb) bind ProjectsDb::class
+                singleOf(::FakeProjectsSync) bind ProjectsSync::class
+                singleOf(::FakeStructuresDb) bind StructuresDb::class
+                singleOf(::FakeStructuresSync) bind StructuresSync::class
+                singleOf(::FakeStructuresPullSyncCoordinator) bind StructuresPullSyncCoordinator::class
+                singleOf(::FakeStructuresPullSyncTimestampDataSource) bind StructuresPullSyncTimestampDataSource::class
+                singleOf(::FakeFindingsDb) bind FindingsDb::class
+            },
+        )
+
+    private val projectId = Uuid.parse("00000000-0000-0000-0000-000000000001")
+    private val structureId = Uuid.parse("00000000-0000-0000-0001-000000000001")
+
+    private fun createProject(id: Uuid) = FrontendProject(
+        project = Project(
+            id = id,
+            name = "Test Project",
+            address = "Test Address",
+            updatedAt = Timestamp(100L),
+        ),
+    )
+
+    private fun createStructure(id: Uuid, projectId: Uuid) = FrontendStructure(
+        structure = Structure(
+            id = id,
+            projectId = projectId,
+            name = "Structure",
+            floorPlanUrl = null,
+            updatedAt = Timestamp(1L),
+        ),
+    )
+
+    @Test
+    fun `deletes project and cascade deletes structures`() = runTest(testDispatcher) {
+        val project = createProject(projectId)
+        fakeProjectsDb.setProject(project)
+
+        val structure = createStructure(id = structureId, projectId = projectId)
+        fakeStructuresDb.setStructure(structure)
+
+        useCase(projectId)
+
+        val projectResult = fakeProjectsDb.getProjectFlow(projectId).first()
+        assertIs<OfflineFirstDataResult.Success<FrontendProject?>>(projectResult)
+        assertNull(projectResult.data)
+
+        val structuresResult = fakeStructuresDb.getStructuresFlow(projectId).first()
+        assertIs<OfflineFirstDataResult.Success<List<FrontendStructure>>>(structuresResult)
+        assertTrue(structuresResult.data.isEmpty())
+    }
+
+    @Test
+    fun `enqueues sync delete on success`() = runTest(testDispatcher) {
+        val project = createProject(projectId)
+        fakeProjectsDb.setProject(project)
+
+        useCase(projectId)
+
+        assertEquals(listOf(projectId), fakeProjectsSync.deletedProjectIds)
+    }
+
+    @Test
+    fun `does not enqueue sync delete on failure`() = runTest(testDispatcher) {
+        fakeProjectsDb.forcedFailure =
+            OfflineFirstDataResult.ProgrammerError(Exception("DB error"))
+
+        useCase(projectId)
+
+        assertTrue(fakeProjectsSync.deletedProjectIds.isEmpty())
+    }
+}

--- a/feat/structures/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/app/impl/internal/DeleteStructureUseCaseImpl.kt
+++ b/feat/structures/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/app/impl/internal/DeleteStructureUseCaseImpl.kt
@@ -12,6 +12,7 @@
 
 package cz.adamec.timotej.snag.structures.fe.app.impl.internal
 
+import cz.adamec.timotej.snag.findings.fe.app.api.DeleteLocalFindingsByStructureIdUseCase
 import cz.adamec.timotej.snag.lib.core.fe.OfflineFirstDataResult
 import cz.adamec.timotej.snag.lib.core.fe.log
 import cz.adamec.timotej.snag.structures.fe.app.api.DeleteStructureUseCase
@@ -23,9 +24,11 @@ import kotlin.uuid.Uuid
 class DeleteStructureUseCaseImpl(
     private val structuresDb: StructuresDb,
     private val structuresSync: StructuresSync,
+    private val deleteLocalFindingsByStructureIdUseCase: DeleteLocalFindingsByStructureIdUseCase,
 ) : DeleteStructureUseCase {
-    override suspend operator fun invoke(structureId: Uuid): OfflineFirstDataResult<Unit> =
-        structuresDb
+    override suspend operator fun invoke(structureId: Uuid): OfflineFirstDataResult<Unit> {
+        deleteLocalFindingsByStructureIdUseCase(structureId)
+        return structuresDb
             .deleteStructure(structureId)
             .also {
                 logger.log(
@@ -36,4 +39,5 @@ class DeleteStructureUseCaseImpl(
                     structuresSync.enqueueStructureDelete(structureId)
                 }
             }
+    }
 }

--- a/feat/structures/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/structures/fe/app/impl/internal/DeleteStructureUseCaseImplTest.kt
+++ b/feat/structures/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/structures/fe/app/impl/internal/DeleteStructureUseCaseImplTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.structures.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.feat.findings.business.Finding
+import cz.adamec.timotej.snag.feat.findings.fe.model.FrontendFinding
+import cz.adamec.timotej.snag.feat.structures.business.Structure
+import cz.adamec.timotej.snag.feat.structures.fe.model.FrontendStructure
+import cz.adamec.timotej.snag.findings.fe.driven.test.FakeFindingsDb
+import cz.adamec.timotej.snag.findings.fe.ports.FindingsDb
+import cz.adamec.timotej.snag.lib.core.common.Timestamp
+import cz.adamec.timotej.snag.lib.core.fe.OfflineFirstDataResult
+import cz.adamec.timotej.snag.structures.fe.app.api.DeleteStructureUseCase
+import cz.adamec.timotej.snag.structures.fe.driven.test.FakeStructuresDb
+import cz.adamec.timotej.snag.structures.fe.driven.test.FakeStructuresPullSyncCoordinator
+import cz.adamec.timotej.snag.structures.fe.driven.test.FakeStructuresPullSyncTimestampDataSource
+import cz.adamec.timotej.snag.structures.fe.driven.test.FakeStructuresSync
+import cz.adamec.timotej.snag.structures.fe.ports.StructuresDb
+import cz.adamec.timotej.snag.structures.fe.ports.StructuresPullSyncCoordinator
+import cz.adamec.timotej.snag.structures.fe.ports.StructuresPullSyncTimestampDataSource
+import cz.adamec.timotej.snag.structures.fe.ports.StructuresSync
+import cz.adamec.timotej.snag.testinfra.fe.FrontendKoinInitializedTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+import org.koin.test.inject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+class DeleteStructureUseCaseImplTest : FrontendKoinInitializedTest() {
+
+    private val fakeStructuresDb: FakeStructuresDb by inject()
+    private val fakeStructuresSync: FakeStructuresSync by inject()
+    private val fakeFindingsDb: FakeFindingsDb by inject()
+
+    private val useCase: DeleteStructureUseCase by inject()
+
+    override fun additionalKoinModules(): List<Module> =
+        listOf(
+            module {
+                singleOf(::FakeStructuresDb) bind StructuresDb::class
+                singleOf(::FakeStructuresSync) bind StructuresSync::class
+                singleOf(::FakeStructuresPullSyncCoordinator) bind StructuresPullSyncCoordinator::class
+                singleOf(::FakeStructuresPullSyncTimestampDataSource) bind StructuresPullSyncTimestampDataSource::class
+                singleOf(::FakeFindingsDb) bind FindingsDb::class
+            },
+        )
+
+    private val projectId = Uuid.parse("00000000-0000-0000-0000-000000000001")
+    private val structureId = Uuid.parse("00000000-0000-0000-0001-000000000001")
+    private val findingId = Uuid.parse("00000000-0000-0000-0002-000000000001")
+
+    private fun createStructure(id: Uuid, projectId: Uuid) = FrontendStructure(
+        structure = Structure(
+            id = id,
+            projectId = projectId,
+            name = "Structure",
+            floorPlanUrl = null,
+            updatedAt = Timestamp(1L),
+        ),
+    )
+
+    private fun createFinding(id: Uuid, structureId: Uuid) = FrontendFinding(
+        finding = Finding(
+            id = id,
+            structureId = structureId,
+            name = "Finding",
+            description = null,
+            coordinates = emptyList(),
+            updatedAt = Timestamp(1L),
+        ),
+    )
+
+    @Test
+    fun `deletes structure and cascade deletes findings`() = runTest(testDispatcher) {
+        val structure = createStructure(id = structureId, projectId = projectId)
+        fakeStructuresDb.setStructure(structure)
+
+        val finding = createFinding(id = findingId, structureId = structureId)
+        fakeFindingsDb.setFindings(listOf(finding))
+
+        useCase(structureId)
+
+        val structureResult = fakeStructuresDb.getStructureFlow(structureId).first()
+        assertIs<OfflineFirstDataResult.Success<FrontendStructure?>>(structureResult)
+        assertNull(structureResult.data)
+
+        val findingsResult = fakeFindingsDb.getFindingsFlow(structureId).first()
+        assertIs<OfflineFirstDataResult.Success<List<FrontendFinding>>>(findingsResult)
+        assertTrue(findingsResult.data.isEmpty())
+    }
+
+    @Test
+    fun `enqueues sync delete on success`() = runTest(testDispatcher) {
+        val structure = createStructure(id = structureId, projectId = projectId)
+        fakeStructuresDb.setStructure(structure)
+
+        useCase(structureId)
+
+        assertEquals(listOf(structureId), fakeStructuresSync.deletedStructureIds)
+    }
+
+    @Test
+    fun `does not enqueue sync delete on failure`() = runTest(testDispatcher) {
+        fakeStructuresDb.forcedFailure =
+            OfflineFirstDataResult.ProgrammerError(Exception("DB error"))
+
+        useCase(structureId)
+
+        assertTrue(fakeStructuresSync.deletedStructureIds.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
- `DeleteProjectUseCaseImpl` now cascade-deletes structures (and their findings) before deleting the project, matching the sync pull behavior
- `DeleteStructureUseCaseImpl` now cascade-deletes findings before deleting the structure, matching the sync pull behavior
- Added tests for both delete use cases verifying cascade behavior and sync enqueue logic

## Test plan
- [x] `./gradlew :feat:projects:fe:app:impl:jvmTest` — 3 new tests pass
- [x] `./gradlew :feat:structures:fe:app:impl:jvmTest` — 3 new tests pass
- [ ] Manually delete a project and verify structures/findings are removed from local DB
- [ ] Manually delete a structure and verify findings are removed from local DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)