### PR TITLE
Add client selection to project create/edit screen

### DIFF
--- a/feat/clients/fe/driving/api/src/commonMain/kotlin/cz/adamec/timotej/snag/clients/fe/driving/api/ClientsRoutes.kt
+++ b/feat/clients/fe/driving/api/src/commonMain/kotlin/cz/adamec/timotej/snag/clients/fe/driving/api/ClientsRoutes.kt
@@ -17,7 +17,13 @@ import kotlin.uuid.Uuid
 
 interface ClientsRoute : SnagNavRoute
 
-interface ClientCreationRoute : SnagNavRoute
+interface ClientCreationRoute : SnagNavRoute {
+    val onCreated: (newClientId: Uuid) -> Unit
+}
+
+interface ClientCreationRouteFactory {
+    fun create(onCreated: (newClientId: Uuid) -> Unit): ClientCreationRoute
+}
 
 interface ClientEditRoute : SnagNavRoute {
     val clientId: Uuid

--- a/feat/clients/fe/driving/api/src/nonWebMain/kotlin/cz/adamec/timotej/snag/clients/fe/driving/api/NonWebClientsRoute.kt
+++ b/feat/clients/fe/driving/api/src/nonWebMain/kotlin/cz/adamec/timotej/snag/clients/fe/driving/api/NonWebClientsRoute.kt
@@ -20,9 +20,14 @@ import kotlin.uuid.Uuid
 @Immutable
 data object NonWebClientsRoute : ClientsRoute
 
-@Serializable
 @Immutable
-data object NonWebClientCreationRoute : ClientCreationRoute
+data class NonWebClientCreationRoute(
+    override val onCreated: (Uuid) -> Unit,
+) : ClientCreationRoute
+
+class NonWebClientCreationRouteFactory : ClientCreationRouteFactory {
+    override fun create(onCreated: (Uuid) -> Unit) = NonWebClientCreationRoute(onCreated)
+}
 
 @Serializable
 @Immutable

--- a/feat/clients/fe/driving/api/src/nonWebMain/kotlin/cz/adamec/timotej/snag/clients/fe/driving/api/di/ClientsDrivingApiModule.nonWeb.kt
+++ b/feat/clients/fe/driving/api/src/nonWebMain/kotlin/cz/adamec/timotej/snag/clients/fe/driving/api/di/ClientsDrivingApiModule.nonWeb.kt
@@ -12,10 +12,10 @@
 
 package cz.adamec.timotej.snag.clients.fe.driving.api.di
 
-import cz.adamec.timotej.snag.clients.fe.driving.api.ClientCreationRoute
+import cz.adamec.timotej.snag.clients.fe.driving.api.ClientCreationRouteFactory
 import cz.adamec.timotej.snag.clients.fe.driving.api.ClientEditRouteFactory
 import cz.adamec.timotej.snag.clients.fe.driving.api.ClientsRoute
-import cz.adamec.timotej.snag.clients.fe.driving.api.NonWebClientCreationRoute
+import cz.adamec.timotej.snag.clients.fe.driving.api.NonWebClientCreationRouteFactory
 import cz.adamec.timotej.snag.clients.fe.driving.api.NonWebClientEditRouteFactory
 import cz.adamec.timotej.snag.clients.fe.driving.api.NonWebClientsRoute
 import org.koin.dsl.bind
@@ -24,6 +24,6 @@ import org.koin.dsl.module
 internal actual val platformModule =
     module {
         factory { NonWebClientsRoute } bind ClientsRoute::class
-        factory { NonWebClientCreationRoute } bind ClientCreationRoute::class
+        factory { NonWebClientCreationRouteFactory() } bind ClientCreationRouteFactory::class
         factory { NonWebClientEditRouteFactory() } bind ClientEditRouteFactory::class
     }

--- a/feat/clients/fe/driving/api/src/webMain/kotlin/cz/adamec/timotej/snag/clients/fe/driving/api/WebClientsRoute.kt
+++ b/feat/clients/fe/driving/api/src/webMain/kotlin/cz/adamec/timotej/snag/clients/fe/driving/api/WebClientsRoute.kt
@@ -22,10 +22,17 @@ data object WebClientsRoute : ClientsRoute {
     const val URL_NAME = "clients"
 }
 
-@Serializable
 @Immutable
-data object WebClientCreationRoute : ClientCreationRoute {
-    const val URL_NAME = "new-client"
+data class WebClientCreationRoute(
+    override val onCreated: (Uuid) -> Unit,
+) : ClientCreationRoute {
+    companion object {
+        const val URL_NAME = "new-client"
+    }
+}
+
+class WebClientCreationRouteFactory : ClientCreationRouteFactory {
+    override fun create(onCreated: (Uuid) -> Unit) = WebClientCreationRoute(onCreated)
 }
 
 @Serializable

--- a/feat/clients/fe/driving/api/src/webMain/kotlin/cz/adamec/timotej/snag/clients/fe/driving/api/di/ClientsDrivingApiModule.web.kt
+++ b/feat/clients/fe/driving/api/src/webMain/kotlin/cz/adamec/timotej/snag/clients/fe/driving/api/di/ClientsDrivingApiModule.web.kt
@@ -12,11 +12,11 @@
 
 package cz.adamec.timotej.snag.clients.fe.driving.api.di
 
-import cz.adamec.timotej.snag.clients.fe.driving.api.ClientCreationRoute
+import cz.adamec.timotej.snag.clients.fe.driving.api.ClientCreationRouteFactory
 import cz.adamec.timotej.snag.clients.fe.driving.api.ClientEditRouteFactory
 import cz.adamec.timotej.snag.clients.fe.driving.api.ClientsBrowserHistoryFragmentBuilder
 import cz.adamec.timotej.snag.clients.fe.driving.api.ClientsRoute
-import cz.adamec.timotej.snag.clients.fe.driving.api.WebClientCreationRoute
+import cz.adamec.timotej.snag.clients.fe.driving.api.WebClientCreationRouteFactory
 import cz.adamec.timotej.snag.clients.fe.driving.api.WebClientEditRouteFactory
 import cz.adamec.timotej.snag.clients.fe.driving.api.WebClientsRoute
 import cz.adamec.timotej.snag.lib.navigation.fe.BrowserHistoryFragmentBuilder
@@ -27,7 +27,7 @@ import org.koin.dsl.module
 internal actual val platformModule =
     module {
         factory { WebClientsRoute } bind ClientsRoute::class
-        factory { WebClientCreationRoute } bind ClientCreationRoute::class
+        factory { WebClientCreationRouteFactory() } bind ClientCreationRouteFactory::class
         factory { WebClientEditRouteFactory() } bind ClientEditRouteFactory::class
         factoryOf(::ClientsBrowserHistoryFragmentBuilder) bind BrowserHistoryFragmentBuilder::class
     }

--- a/feat/clients/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/clients/fe/driving/impl/di/ClientsDrivingModule.kt
+++ b/feat/clients/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/clients/fe/driving/impl/di/ClientsDrivingModule.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.window.DialogProperties
 import androidx.navigation3.scene.DialogSceneStrategy
 import cz.adamec.timotej.snag.clients.fe.driving.api.ClientCreationRoute
+import cz.adamec.timotej.snag.clients.fe.driving.api.ClientCreationRouteFactory
 import cz.adamec.timotej.snag.clients.fe.driving.api.ClientEditRoute
 import cz.adamec.timotej.snag.clients.fe.driving.api.ClientEditRouteFactory
 import cz.adamec.timotej.snag.clients.fe.driving.api.ClientsRoute
@@ -42,8 +43,8 @@ internal inline fun <reified T : ClientsRoute> Module.clientsScreenNavigation() 
             viewModel = koinViewModel(),
             onNewClientClick = {
                 val backStack = get<SnagBackStack>()
-                val clientCreationRoute = get<ClientCreationRoute>()
-                backStack.value.add(clientCreationRoute)
+                val factory = get<ClientCreationRouteFactory>()
+                backStack.value.add(factory.create { })
             },
             onClientClick = { clientId ->
                 val backStack = get<SnagBackStack>()
@@ -57,9 +58,10 @@ internal inline fun <reified T : ClientsRoute> Module.clientsScreenNavigation() 
 internal inline fun <reified T : ClientCreationRoute> Module.clientCreationScreenNavigation() =
     navigation<T>(
         metadata = DialogSceneStrategy.dialog(DialogProperties(usePlatformDefaultWidth = false)),
-    ) { _ ->
+    ) { route ->
         ClientDetailsEditScreenInjection(
-            onSaveClient = { _ ->
+            onSaveClient = { savedClientId ->
+                route.onCreated(savedClientId)
                 val backStack = get<SnagBackStack>()
                 backStack.removeLastSafely()
             },

--- a/feat/projects/fe/driving/impl/build.gradle.kts
+++ b/feat/projects/fe/driving/impl/build.gradle.kts
@@ -23,6 +23,8 @@ kotlin {
                 implementation(project(":feat:projects:business"))
                 implementation(project(":feat:structures:fe:app:api"))
                 implementation(project(":feat:structures:fe:driving:api"))
+                implementation(project(":feat:clients:fe:app:api"))
+                implementation(project(":feat:clients:fe:driving:api"))
             }
         }
         commonTest {
@@ -30,6 +32,8 @@ kotlin {
 //                TODO()
                 implementation(project(":feat:projects:fe:app:impl"))
                 implementation(project(":feat:projects:fe:driven:test"))
+                implementation(project(":feat:clients:fe:app:impl"))
+                implementation(project(":feat:clients:fe:driven:test"))
             }
         }
     }

--- a/feat/projects/fe/driving/impl/src/commonMain/composeResources/values/strings.xml
+++ b/feat/projects/fe/driving/impl/src/commonMain/composeResources/values/strings.xml
@@ -21,4 +21,7 @@
     <string name="delete_project_confirmation_text">Project will be deleted permanently locally and on the server.</string>
 
     <string name="required">Required</string>
+    <string name="client_label">Client</string>
+    <string name="none">None</string>
+    <string name="create_new_client">Create new client</string>
 </resources>

--- a/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/di/ProjectsDrivingModule.kt
+++ b/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/di/ProjectsDrivingModule.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation3.scene.DialogSceneStrategy
+import cz.adamec.timotej.snag.clients.fe.driving.api.ClientCreationRouteFactory
 import cz.adamec.timotej.snag.lib.design.fe.dialog.fullscreenDialogProperties
 import cz.adamec.timotej.snag.feat.structures.fe.driving.api.StructureCreationRouteFactory
 import cz.adamec.timotej.snag.feat.structures.fe.driving.api.StructureDetailRouteFactory
@@ -96,6 +97,7 @@ private fun Scope.ProjectDetailsEditScreenInjection(
     projectId: Uuid? = null,
     onSaveProject: (savedProjectId: Uuid) -> Unit,
 ) {
+    val clientCreationRouteFactory = koinInject<ClientCreationRouteFactory>()
     ProjectDetailsEditScreen(
         projectId = projectId,
         onSaveProject = { savedProjectId ->
@@ -104,6 +106,10 @@ private fun Scope.ProjectDetailsEditScreenInjection(
         onCancelClick = {
             val backStack = get<SnagBackStack>()
             backStack.removeLastSafely()
+        },
+        onNavigateToClientCreation = { onCreated ->
+            val backStack = get<SnagBackStack>()
+            backStack.value.add(clientCreationRouteFactory.create(onCreated))
         },
     )
 }
@@ -143,6 +149,7 @@ val projectsDrivingImplModule =
                 projectId = projectId,
                 getProjectUseCase = get(),
                 saveProjectUseCase = get(),
+                getClientsUseCase = get(),
             )
         }
         viewModel { (projectId: Uuid) ->

--- a/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetailsEdit/ui/ProjectDetailsEditContent.kt
+++ b/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetailsEdit/ui/ProjectDetailsEditContent.kt
@@ -19,8 +19,14 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -28,17 +34,25 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import cz.adamec.timotej.snag.projects.fe.driving.impl.internal.projectDetailsEdit.vm.ProjectDetailsEditUiState
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import snag.feat.projects.fe.driving.impl.generated.resources.Res
+import snag.feat.projects.fe.driving.impl.generated.resources.client_label
+import snag.feat.projects.fe.driving.impl.generated.resources.create_new_client
 import snag.feat.projects.fe.driving.impl.generated.resources.new_project
+import snag.feat.projects.fe.driving.impl.generated.resources.none
 import snag.feat.projects.fe.driving.impl.generated.resources.project_address_label
 import snag.feat.projects.fe.driving.impl.generated.resources.project_name_label
 import snag.feat.projects.fe.driving.impl.generated.resources.required
 import snag.lib.design.fe.generated.resources.close
+import snag.lib.design.fe.generated.resources.ic_add
 import snag.lib.design.fe.generated.resources.ic_close
 import snag.lib.design.fe.generated.resources.ic_location
 import snag.lib.design.fe.generated.resources.save
@@ -55,6 +69,9 @@ internal fun ProjectDetailsEditContent(
     snackbarHostState: SnackbarHostState,
     onProjectNameChange: (String) -> Unit,
     onProjectAddressChange: (String) -> Unit,
+    onSelectClient: (Uuid, String) -> Unit,
+    onClearClient: () -> Unit,
+    onCreateNewClientClick: () -> Unit,
     onSaveClick: () -> Unit,
     onCancelClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -141,6 +158,80 @@ internal fun ProjectDetailsEditContent(
                         painter = painterResource(DesignRes.drawable.ic_location),
                         contentDescription = "Address",
                     )
+                },
+            )
+            ClientDropdown(
+                state = state,
+                onSelectClient = onSelectClient,
+                onClearClient = onClearClient,
+                onCreateNewClientClick = onCreateNewClientClick,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ClientDropdown(
+    state: ProjectDetailsEditUiState,
+    onSelectClient: (Uuid, String) -> Unit,
+    onClearClient: () -> Unit,
+    onCreateNewClientClick: () -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+    ) {
+        OutlinedTextField(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+            label = { Text(stringResource(Res.string.client_label)) },
+            value = state.selectedClientName,
+            onValueChange = {},
+            readOnly = true,
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            DropdownMenuItem(
+                text = { Text(stringResource(Res.string.none)) },
+                onClick = {
+                    onClearClient()
+                    expanded = false
+                },
+            )
+            HorizontalDivider()
+            state.availableClients.forEach { frontendClient ->
+                DropdownMenuItem(
+                    text = { Text(frontendClient.client.name) },
+                    onClick = {
+                        onSelectClient(frontendClient.client.id, frontendClient.client.name)
+                        expanded = false
+                    },
+                )
+            }
+            HorizontalDivider()
+            DropdownMenuItem(
+                text = {
+                    Text(
+                        text = stringResource(Res.string.create_new_client),
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                },
+                leadingIcon = {
+                    Icon(
+                        painter = painterResource(DesignRes.drawable.ic_add),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                },
+                onClick = {
+                    expanded = false
+                    onCreateNewClientClick()
                 },
             )
         }

--- a/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetailsEdit/ui/ProjectDetailsEditScreen.kt
+++ b/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetailsEdit/ui/ProjectDetailsEditScreen.kt
@@ -41,6 +41,7 @@ import kotlin.uuid.Uuid
 internal fun ProjectDetailsEditScreen(
     onSaveProject: (projectId: Uuid) -> Unit,
     onCancelClick: () -> Unit,
+    onNavigateToClientCreation: (onCreated: (Uuid) -> Unit) -> Unit,
     projectId: Uuid? = null,
     viewModel: ProjectDetailsEditViewModel =
         koinViewModel(
@@ -90,6 +91,13 @@ internal fun ProjectDetailsEditScreen(
         },
         onProjectAddressChange = {
             viewModel.onProjectAddressChange(it)
+        },
+        onSelectClient = { id, name -> viewModel.onClientSelected(id, name) },
+        onClearClient = { viewModel.onClientCleared() },
+        onCreateNewClientClick = {
+            onNavigateToClientCreation { clientId ->
+                viewModel.onClientCreated(clientId)
+            }
         },
         onSaveClick = {
             viewModel.onSaveProject()

--- a/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetailsEdit/vm/ProjectDetailsEditUiState.kt
+++ b/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetailsEdit/vm/ProjectDetailsEditUiState.kt
@@ -12,7 +12,15 @@
 
 package cz.adamec.timotej.snag.projects.fe.driving.impl.internal.projectDetailsEdit.vm
 
+import cz.adamec.timotej.snag.clients.fe.model.FrontendClient
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlin.uuid.Uuid
+
 internal data class ProjectDetailsEditUiState(
     val projectName: String = "",
     val projectAddress: String = "",
+    val selectedClientId: Uuid? = null,
+    val selectedClientName: String = "",
+    val availableClients: ImmutableList<FrontendClient> = persistentListOf(),
 )

--- a/feat/projects/fe/driving/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetailsEdit/vm/ProjectDetailsEditViewModelTest.kt
+++ b/feat/projects/fe/driving/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetailsEdit/vm/ProjectDetailsEditViewModelTest.kt
@@ -12,16 +12,29 @@
 
 package cz.adamec.timotej.snag.projects.fe.driving.impl.internal.projectDetailsEdit.vm
 
+import cz.adamec.timotej.snag.clients.business.Client
+import cz.adamec.timotej.snag.clients.fe.app.api.GetClientsUseCase
+import cz.adamec.timotej.snag.clients.fe.driven.test.FakeClientsApi
+import cz.adamec.timotej.snag.clients.fe.driven.test.FakeClientsDb
+import cz.adamec.timotej.snag.clients.fe.driven.test.FakeClientsPullSyncCoordinator
+import cz.adamec.timotej.snag.clients.fe.driven.test.FakeClientsPullSyncTimestampDataSource
+import cz.adamec.timotej.snag.clients.fe.driven.test.FakeClientsSync
+import cz.adamec.timotej.snag.clients.fe.model.FrontendClient
+import cz.adamec.timotej.snag.clients.fe.ports.ClientsApi
+import cz.adamec.timotej.snag.clients.fe.ports.ClientsDb
+import cz.adamec.timotej.snag.clients.fe.ports.ClientsPullSyncCoordinator
+import cz.adamec.timotej.snag.clients.fe.ports.ClientsPullSyncTimestampDataSource
+import cz.adamec.timotej.snag.clients.fe.ports.ClientsSync
 import cz.adamec.timotej.snag.lib.core.common.Timestamp
 import cz.adamec.timotej.snag.lib.core.fe.OfflineFirstDataResult
 import cz.adamec.timotej.snag.lib.design.fe.error.UiError
 import cz.adamec.timotej.snag.projects.business.Project
 import cz.adamec.timotej.snag.projects.fe.app.api.GetProjectUseCase
-import cz.adamec.timotej.snag.projects.fe.model.FrontendProject
 import cz.adamec.timotej.snag.projects.fe.app.api.SaveProjectUseCase
 import cz.adamec.timotej.snag.projects.fe.driven.test.FakeProjectsApi
 import cz.adamec.timotej.snag.projects.fe.driven.test.FakeProjectsDb
 import cz.adamec.timotej.snag.projects.fe.driven.test.FakeProjectsSync
+import cz.adamec.timotej.snag.projects.fe.model.FrontendProject
 import cz.adamec.timotej.snag.projects.fe.ports.ProjectsApi
 import cz.adamec.timotej.snag.projects.fe.ports.ProjectsDb
 import cz.adamec.timotej.snag.projects.fe.ports.ProjectsSync
@@ -38,15 +51,17 @@ import org.koin.test.inject
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 import kotlin.uuid.Uuid
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ProjectDetailsEditViewModelTest : FrontendKoinInitializedTest() {
-
     private val fakeProjectsDb: FakeProjectsDb by inject()
+    private val fakeClientsDb: FakeClientsDb by inject()
 
     private val getProjectUseCase: GetProjectUseCase by inject()
     private val saveProjectUseCase: SaveProjectUseCase by inject()
+    private val getClientsUseCase: GetClientsUseCase by inject()
 
     override fun additionalKoinModules(): List<Module> =
         listOf(
@@ -54,6 +69,11 @@ class ProjectDetailsEditViewModelTest : FrontendKoinInitializedTest() {
                 singleOf(::FakeProjectsApi) bind ProjectsApi::class
                 singleOf(::FakeProjectsDb) bind ProjectsDb::class
                 singleOf(::FakeProjectsSync) bind ProjectsSync::class
+                singleOf(::FakeClientsApi) bind ClientsApi::class
+                singleOf(::FakeClientsDb) bind ClientsDb::class
+                singleOf(::FakeClientsSync) bind ClientsSync::class
+                singleOf(::FakeClientsPullSyncCoordinator) bind ClientsPullSyncCoordinator::class
+                singleOf(::FakeClientsPullSyncTimestampDataSource) bind ClientsPullSyncTimestampDataSource::class
             },
         )
 
@@ -62,6 +82,7 @@ class ProjectDetailsEditViewModelTest : FrontendKoinInitializedTest() {
             projectId = projectId,
             getProjectUseCase = getProjectUseCase,
             saveProjectUseCase = saveProjectUseCase,
+            getClientsUseCase = getClientsUseCase,
         )
 
     @Test
@@ -71,13 +92,24 @@ class ProjectDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
             assertEquals("", viewModel.state.value.projectName)
             assertEquals("", viewModel.state.value.projectAddress)
+            assertNull(viewModel.state.value.selectedClientId)
+            assertEquals("", viewModel.state.value.selectedClientName)
         }
 
     @Test
     fun `loading project data updates state when projectId is provided`() =
         runTest {
             val projectId = Uuid.random()
-            val project = FrontendProject(project = Project(projectId, "Test Project", "Test Address", Timestamp(10L)))
+            val project =
+                FrontendProject(
+                    project =
+                        Project(
+                            id = projectId,
+                            name = "Test Project",
+                            address = "Test Address",
+                            updatedAt = Timestamp(10L),
+                        ),
+                )
             fakeProjectsDb.setProject(project)
 
             val viewModel = createViewModel(projectId = projectId)
@@ -166,5 +198,138 @@ class ProjectDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
             val error = viewModel.errorsFlow.first()
             assertIs<UiError.Unknown>(error)
+        }
+
+    @Test
+    fun `clients are loaded into state`() =
+        runTest {
+            val clientId = Uuid.random()
+            fakeClientsDb.setClient(
+                FrontendClient(
+                    client =
+                        Client(
+                            id = clientId,
+                            name = "ACME Corp",
+                            address = null,
+                            phoneNumber = null,
+                            email = null,
+                            updatedAt = Timestamp(10L),
+                        ),
+                ),
+            )
+
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            val clients = viewModel.state.value.availableClients
+            assertEquals(1, clients.size)
+            assertEquals("ACME Corp", clients[0].client.name)
+        }
+
+    @Test
+    fun `selecting a client updates state`() =
+        runTest {
+            val clientId = Uuid.random()
+            val viewModel = createViewModel()
+
+            viewModel.onClientSelected(clientId, "ACME Corp")
+
+            assertEquals(clientId, viewModel.state.value.selectedClientId)
+            assertEquals("ACME Corp", viewModel.state.value.selectedClientName)
+        }
+
+    @Test
+    fun `clearing client selection updates state`() =
+        runTest {
+            val clientId = Uuid.random()
+            val viewModel = createViewModel()
+            viewModel.onClientSelected(clientId, "ACME Corp")
+
+            viewModel.onClientCleared()
+
+            assertNull(viewModel.state.value.selectedClientId)
+            assertEquals("", viewModel.state.value.selectedClientName)
+        }
+
+    @Test
+    fun `saving project with client includes clientId`() =
+        runTest {
+            val clientId = Uuid.random()
+            val viewModel = createViewModel()
+            viewModel.onProjectNameChange("Name")
+            viewModel.onProjectAddressChange("Address")
+            viewModel.onClientSelected(clientId, "ACME Corp")
+
+            viewModel.onSaveProject()
+
+            val savedId = viewModel.saveEventFlow.first()
+            val savedProjectResult = fakeProjectsDb.getProjectFlow(savedId).first()
+            assertIs<OfflineFirstDataResult.Success<FrontendProject?>>(savedProjectResult)
+            assertEquals(clientId, savedProjectResult.data?.project?.clientId)
+        }
+
+    @Test
+    fun `editing project with clientId pre-selects client`() =
+        runTest {
+            val projectId = Uuid.random()
+            val clientId = Uuid.random()
+            fakeClientsDb.setClient(
+                FrontendClient(
+                    client =
+                        Client(
+                            id = clientId,
+                            name = "ACME Corp",
+                            address = null,
+                            phoneNumber = null,
+                            email = null,
+                            updatedAt = Timestamp(10L),
+                        ),
+                ),
+            )
+            fakeProjectsDb.setProject(
+                FrontendProject(
+                    project =
+                        Project(
+                            id = projectId,
+                            name = "Test Project",
+                            address = "Test Address",
+                            clientId = clientId,
+                            updatedAt = Timestamp(10L),
+                        ),
+                ),
+            )
+
+            val viewModel = createViewModel(projectId = projectId)
+            advanceUntilIdle()
+
+            assertEquals(clientId, viewModel.state.value.selectedClientId)
+            assertEquals("ACME Corp", viewModel.state.value.selectedClientName)
+        }
+
+    @Test
+    fun `onClientCreated selects newly created client`() =
+        runTest {
+            val clientId = Uuid.random()
+            fakeClientsDb.setClient(
+                FrontendClient(
+                    client =
+                        Client(
+                            id = clientId,
+                            name = "New Client",
+                            address = null,
+                            phoneNumber = null,
+                            email = null,
+                            updatedAt = Timestamp(10L),
+                        ),
+                ),
+            )
+
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.onClientCreated(clientId)
+
+            assertEquals(clientId, viewModel.state.value.selectedClientId)
+            assertEquals("New Client", viewModel.state.value.selectedClientName)
         }
 }


### PR DESCRIPTION
## Summary
- Add optional client dropdown (`ExposedDropdownMenuBox`) to the project details edit form with "None", existing clients, and "Create new client" options
- Introduce `ClientCreationRouteFactory` with `onCreated` callback so the newly created client ID flows back to the project edit ViewModel automatically
- Wire cross-feature dependencies (projects → clients) for use cases, routes, and test fakes

## Test plan
- [x] 13 ViewModel tests pass (8 existing + 5 new client-related tests)
- [ ] Manual: create project → client dropdown shows → select client → save → verify `clientId` persisted
- [ ] Manual: edit project with existing client → verify pre-selected in dropdown
- [ ] Manual: click "Create new client" → create client → verify auto-selected on return
- [ ] Manual: select "None" to clear client → save → verify `clientId` is null

🤖 Generated with [Claude Code](https://claude.com/claude-code)