### PR TITLE
Add visual FindingType differentiation across UI

### DIFF
--- a/feat/findings/fe/driving/api/src/commonMain/kotlin/cz/adamec/timotej/snag/feat/findings/fe/driving/api/FindingTypeVisuals.kt
+++ b/feat/findings/fe/driving/api/src/commonMain/kotlin/cz/adamec/timotej/snag/feat/findings/fe/driving/api/FindingTypeVisuals.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.feat.findings.fe.driving.api
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import cz.adamec.timotej.snag.feat.findings.business.FindingType
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.StringResource
+import snag.lib.design.fe.generated.resources.Res
+import snag.lib.design.fe.generated.resources.finding_type_classic
+import snag.lib.design.fe.generated.resources.finding_type_note
+import snag.lib.design.fe.generated.resources.finding_type_unvisited
+import snag.lib.design.fe.generated.resources.ic_finding_classic
+import snag.lib.design.fe.generated.resources.ic_finding_note
+import snag.lib.design.fe.generated.resources.ic_finding_unvisited
+
+data class FindingTypeVisuals(
+    val icon: DrawableResource,
+    val label: StringResource,
+    val pinColor: Color,
+)
+
+@Composable
+fun findingTypeVisuals(type: FindingType): FindingTypeVisuals =
+    when (type) {
+        is FindingType.Classic ->
+            FindingTypeVisuals(
+                icon = Res.drawable.ic_finding_classic,
+                label = Res.string.finding_type_classic,
+                pinColor = MaterialTheme.colorScheme.error,
+            )
+
+        is FindingType.Unvisited ->
+            FindingTypeVisuals(
+                icon = Res.drawable.ic_finding_unvisited,
+                label = Res.string.finding_type_unvisited,
+                pinColor = MaterialTheme.colorScheme.outline,
+            )
+
+        is FindingType.Note ->
+            FindingTypeVisuals(
+                icon = Res.drawable.ic_finding_note,
+                label = Res.string.finding_type_note,
+                pinColor = MaterialTheme.colorScheme.tertiary,
+            )
+    }

--- a/feat/findings/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driving/impl/internal/findingDetail/ui/FindingDetailContent.kt
+++ b/feat/findings/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driving/impl/internal/findingDetail/ui/FindingDetailContent.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ContainedLoadingIndicator
 import androidx.compose.material3.HorizontalFloatingToolbar
 import androidx.compose.material3.Icon
@@ -44,6 +45,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import cz.adamec.timotej.snag.feat.findings.business.FindingType
+import cz.adamec.timotej.snag.feat.findings.fe.driving.api.findingTypeVisuals
 import cz.adamec.timotej.snag.findings.fe.driving.impl.internal.findingDetail.ui.components.FindingDeletionAlertDialog
 import cz.adamec.timotej.snag.findings.fe.driving.impl.internal.findingDetail.ui.components.ImportanceLabel
 import cz.adamec.timotej.snag.findings.fe.driving.impl.internal.findingDetail.ui.components.TermLabel
@@ -164,8 +166,26 @@ internal fun FindingDetailContent(
                 ) {
                     Column {
                         val type = finding.finding.type
+                        val visuals = findingTypeVisuals(type)
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Icon(
+                                painter = painterResource(visuals.icon),
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp),
+                                tint = visuals.pinColor,
+                            )
+                            Text(
+                                text = stringResource(visuals.label),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
                         if (type is FindingType.Classic) {
                             Row(
+                                modifier = Modifier.padding(top = 8.dp),
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                             ) {
                                 ImportanceLabel(

--- a/feat/findings/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driving/impl/internal/findingDetailsEdit/ui/FindingDetailsEditContent.kt
+++ b/feat/findings/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driving/impl/internal/findingDetailsEdit/ui/FindingDetailsEditContent.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonGroupDefaults
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -33,14 +34,17 @@ import androidx.compose.material3.ToggleButton
 import androidx.compose.material3.ToggleButtonDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import cz.adamec.timotej.snag.feat.findings.business.FindingType
 import cz.adamec.timotej.snag.feat.findings.business.Importance
 import cz.adamec.timotej.snag.feat.findings.business.Term
+import cz.adamec.timotej.snag.feat.findings.fe.driving.api.findingTypeVisuals
 import cz.adamec.timotej.snag.findings.fe.driving.impl.internal.findingDetailsEdit.vm.FindingDetailsEditUiState
 import cz.adamec.timotej.snag.lib.design.fe.dialog.FullScreenDialogMeasurements
 import cz.adamec.timotej.snag.lib.design.fe.theme.SnagTheme
@@ -154,6 +158,23 @@ internal fun FindingDetailsEditContent(
                     onFindingNameChange(it)
                 },
             )
+            val visuals = findingTypeVisuals(state.findingType)
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Icon(
+                    painter = painterResource(visuals.icon),
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                    tint = visuals.pinColor,
+                )
+                Text(
+                    text = stringResource(visuals.label),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
             val classicType = state.findingType as? FindingType.Classic
             if (classicType != null) {
                 Text(

--- a/feat/findings/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driving/impl/internal/findingsList/ui/FindingsListContent.kt
+++ b/feat/findings/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driving/impl/internal/findingsList/ui/FindingsListContent.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ContainedLoadingIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
@@ -33,10 +34,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+import cz.adamec.timotej.snag.feat.findings.fe.driving.api.findingTypeVisuals
 import cz.adamec.timotej.snag.feat.findings.fe.model.FrontendFinding
 import cz.adamec.timotej.snag.findings.fe.driving.impl.internal.findingsList.vm.FindingsListUiState
 import cz.adamec.timotej.snag.findings.fe.driving.impl.internal.findingsList.vm.FindingsListUiStatus
 import cz.adamec.timotej.snag.lib.design.fe.scenes.LocalIsInSheet
+import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import snag.feat.findings.fe.driving.impl.generated.resources.Res
 import snag.feat.findings.fe.driving.impl.generated.resources.no_findings_yet_message
@@ -134,6 +137,14 @@ private fun FindingsList(
                     } else {
                         ListItemDefaults.colors()
                     },
+                leadingContent = {
+                    val visuals = findingTypeVisuals(finding.finding.type)
+                    Icon(
+                        painter = painterResource(visuals.icon),
+                        contentDescription = stringResource(visuals.label),
+                        tint = visuals.pinColor,
+                    )
+                },
                 headlineContent = {
                     Text(text = finding.finding.name)
                 },

--- a/feat/structures/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/internal/floorPlan/ui/components/FloorPlanWithPins.kt
+++ b/feat/structures/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/internal/floorPlan/ui/components/FloorPlanWithPins.kt
@@ -20,18 +20,21 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.drawscope.DrawScope
-import androidx.compose.ui.graphics.drawscope.Fill
-import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import com.github.panpf.zoomimage.CoilZoomAsyncImage
 import com.github.panpf.zoomimage.CoilZoomState
 import com.github.panpf.zoomimage.rememberCoilZoomState
+import cz.adamec.timotej.snag.feat.findings.business.FindingType
+import cz.adamec.timotej.snag.feat.findings.fe.driving.api.findingTypeVisuals
 import cz.adamec.timotej.snag.feat.findings.fe.model.FrontendFinding
 import kotlinx.collections.immutable.ImmutableList
+import org.jetbrains.compose.resources.painterResource
 import kotlin.math.sqrt
 import kotlin.uuid.Uuid
 
@@ -75,7 +78,6 @@ internal fun FloorPlanWithPins(
     }
 }
 
-
 @Composable
 private fun FindingsPinsOverlay(
     zoomableState: CoilZoomState,
@@ -86,8 +88,15 @@ private fun FindingsPinsOverlay(
     val displayRect = zoomableState.zoomable.contentDisplayRectF
     if (displayRect.isEmpty) return
 
-    val pinColor = MaterialTheme.colorScheme.error
-    val selectedPinColor = MaterialTheme.colorScheme.tertiary
+    val classicVisuals = findingTypeVisuals(FindingType.Classic())
+    val unvisitedVisuals = findingTypeVisuals(FindingType.Unvisited)
+    val noteVisuals = findingTypeVisuals(FindingType.Note)
+
+    val classicPainter = painterResource(classicVisuals.icon)
+    val unvisitedPainter = painterResource(unvisitedVisuals.icon)
+    val notePainter = painterResource(noteVisuals.icon)
+
+    val selectedPinColor = MaterialTheme.colorScheme.primary
 
     Canvas(modifier = modifier.fillMaxSize()) {
         findings.forEach { finding ->
@@ -98,11 +107,20 @@ private fun FindingsPinsOverlay(
                         y = displayRect.top + coord.y * displayRect.height,
                     )
                 val isSelected = finding.finding.id == selectedFindingId
+                val size = if (isSelected) 32.dp.toPx() else 24.dp.toPx()
+
+                val (painter, color) =
+                    when (finding.finding.type) {
+                        is FindingType.Classic -> classicPainter to classicVisuals.pinColor
+                        is FindingType.Unvisited -> unvisitedPainter to unvisitedVisuals.pinColor
+                        is FindingType.Note -> notePainter to noteVisuals.pinColor
+                    }
 
                 drawFindingPin(
                     center = drawPoint,
-                    fillColor = if (isSelected) selectedPinColor else pinColor,
-                    radius = if (isSelected) 16.dp.toPx() else 12.dp.toPx(),
+                    painter = painter,
+                    size = size,
+                    tint = if (isSelected) selectedPinColor else color,
                 )
             }
         }
@@ -111,15 +129,21 @@ private fun FindingsPinsOverlay(
 
 private fun DrawScope.drawFindingPin(
     center: Offset,
-    fillColor: Color,
-    radius: Float,
+    painter: Painter,
+    size: Float,
+    tint: androidx.compose.ui.graphics.Color,
 ) {
-    drawCircle(
-        color = fillColor,
-        radius = radius,
-        center = center,
-        style = Fill,
-    )
+    translate(
+        left = center.x - size / 2,
+        top = center.y - size / 2,
+    ) {
+        with(painter) {
+            draw(
+                size = Size(size, size),
+                colorFilter = androidx.compose.ui.graphics.ColorFilter.tint(tint),
+            )
+        }
+    }
 }
 
 private fun findTappedFinding(

--- a/lib/design/fe/src/commonMain/composeResources/drawable/ic_finding_classic.xml
+++ b/lib/design/fe/src/commonMain/composeResources/drawable/ic_finding_classic.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M480,480q33,0 56.5,-23.5T560,400q0,-33 -23.5,-56.5T480,320q-33,0 -56.5,23.5T400,400q0,33 23.5,56.5T480,480Zm0,294q122,-112 181,-203.5T720,408q0,-109 -69.5,-178.5T480,160q-101,0 -170.5,69.5T240,408q0,71 59,162.5T480,774Zm0,106Q319,743 239.5,625.5T160,408q0,-150 96.5,-239T480,80q127,0 223.5,89T800,408q0,100 -79.5,217.5T480,880Zm0,-480Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/lib/design/fe/src/commonMain/composeResources/drawable/ic_finding_note.xml
+++ b/lib/design/fe/src/commonMain/composeResources/drawable/ic_finding_note.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M480,880Q319,743 239.5,625.5T160,408q0,-150 96.5,-239T480,80q27,0 53.5,4.5T585,97l-65,66q-10,-2 -19.5,-2.5T480,160q-101,0 -170.5,69.5T240,408q0,71 59,162.5T480,774q122,-112 181,-203.5T720,408q0,-12 -1,-24t-3,-23l66,-66q9,26 13.5,54t4.5,59q0,100 -79.5,217.5T480,880Zm0,-472Zm254,-254 -46,-46 -248,248v84h84l248,-248 -38,-38Zm66,10 28,-28q11,-11 11,-28t-11,-28l-28,-28q-11,-11 -28,-11t-28,11l-28,28 84,84Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/lib/design/fe/src/commonMain/composeResources/drawable/ic_finding_unvisited.xml
+++ b/lib/design/fe/src/commonMain/composeResources/drawable/ic_finding_unvisited.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M480,880Q319,743 239.5,625.5T160,408q0,-150 96.5,-239T480,80q10,0 19.5,0.5T520,83v81q-10,-2 -20,-3t-20,-1q-101,0 -170.5,69.5T240,408q0,71 59,162.5T480,774q122,-112 181,-203.5T720,408q0,2 -0.5,-4t-0.5,-4h80q0,2 0.5,4t0.5,4q0,100 -79.5,217.5T480,880Zm0,-450Zm195,-108 84,-84 84,84 56,-56 -84,-84 84,-84 -56,-56 -84,84 -84,-84 -56,56 84,84 -84,84 56,56ZM480,480q33,0 56.5,-23.5T560,400q0,-33 -23.5,-56.5T480,320q-33,0 -56.5,23.5T480,480Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/lib/design/fe/src/commonMain/composeResources/values/strings.xml
+++ b/lib/design/fe/src/commonMain/composeResources/values/strings.xml
@@ -25,4 +25,7 @@
     <string name="sync_status_syncing">Syncing…</string>
     <string name="sync_status_offline">Offline</string>
     <string name="sync_status_error">Sync error</string>
+    <string name="finding_type_classic">Classic</string>
+    <string name="finding_type_unvisited">Unvisited</string>
+    <string name="finding_type_note">Note</string>
 </resources>


### PR DESCRIPTION
## Summary
- Add type-specific icons (location_on, wrong_location, edit_location_alt) and colors (error/outline/tertiary) for Classic, Unvisited, and Note findings
- Show type indicator with icon + label in findings list (leading content), detail screen, and edit screen
- Differentiate floor plan pins by type color and inner marker shape (dot/X/ring) for colorblind accessibility
- Shared `FindingTypeVisuals` utility in `findings:fe:driving:api` consumed by both findings and structures modules

## Test plan
- [ ] Run desktop app, create findings of each type (Classic, Unvisited, Note)
- [ ] Verify findings list shows different colored icons per type
- [ ] Verify detail screen shows type label + icon; Classic still shows importance/term, others don't
- [ ] Verify edit screen shows type indicator; Classic still has importance/term toggles
- [ ] Verify floor plan pins have different colors and inner markers per type
- [ ] Verify selected pin uses primary color regardless of type

🤖 Generated with [Claude Code](https://claude.com/claude-code)