### PR TITLE
Add white halo and colored ring to floor plan pins

### DIFF
--- a/feat/structures/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/internal/floorPlan/ui/components/FloorPlanWithPins.kt
+++ b/feat/structures/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/internal/floorPlan/ui/components/FloorPlanWithPins.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.painter.Painter
@@ -133,6 +134,24 @@ private fun DrawScope.drawFindingPin(
     size: Float,
     tint: androidx.compose.ui.graphics.Color,
 ) {
+    val haloRadius = size / 2 + 3.dp.toPx()
+    val ringRadius = size / 2 + 1.dp.toPx()
+
+    // Draw white halo (outermost layer)
+    drawCircle(
+        color = Color.White,
+        radius = haloRadius,
+        center = center,
+    )
+
+    // Draw colored ring
+    drawCircle(
+        color = tint,
+        radius = ringRadius,
+        center = center,
+    )
+
+    // Draw white icon on top
     translate(
         left = center.x - size / 2,
         top = center.y - size / 2,
@@ -140,7 +159,7 @@ private fun DrawScope.drawFindingPin(
         with(painter) {
             draw(
                 size = Size(size, size),
-                colorFilter = androidx.compose.ui.graphics.ColorFilter.tint(tint),
+                colorFilter = androidx.compose.ui.graphics.ColorFilter.tint(Color.White),
             )
         }
     }


### PR DESCRIPTION
## Summary
- Replace simple icon rendering with layered pin design for maximum visibility against busy floor plans
- Add white halo (outermost, 3dp padding) to ensure pins stand out on any background color
- Add colored ring (1dp padding) in type-specific color (error/outline/tertiary, or primary for selected)
- Render white icon on top for clear contrast against the colored ring

## Visual structure
```
[White halo] → [Colored type ring] → [White icon]
```

This creates a "bullseye" effect that stands out on complex floor plans while maintaining semantic meaning through icon shape and color.

## Test plan
- [ ] Run desktop app, view floor plan with findings
- [ ] Verify pins are clearly visible on both light and dark areas of the floor plan
- [ ] Verify type colors are distinguishable (red/gray/teal rings)
- [ ] Verify selected pins use primary color ring
- [ ] Verify icon shapes (location_on/wrong_location/edit_location_alt) are visible as white icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)