### PR TITLE
Fix floor plan icon clipping by increasing size and using diagonal calculation

### DIFF
--- a/feat/structures/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/internal/floorPlan/ui/components/FloorPlanWithPins.kt
+++ b/feat/structures/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/internal/floorPlan/ui/components/FloorPlanWithPins.kt
@@ -108,7 +108,7 @@ private fun FindingsPinsOverlay(
                         y = displayRect.top + coord.y * displayRect.height,
                     )
                 val isSelected = finding.finding.id == selectedFindingId
-                val size = if (isSelected) 32.dp.toPx() else 24.dp.toPx()
+                val iconSize = if (isSelected) 36.dp.toPx() else 28.dp.toPx()
 
                 val (painter, color) =
                     when (finding.finding.type) {
@@ -120,7 +120,7 @@ private fun FindingsPinsOverlay(
                 drawFindingPin(
                     center = drawPoint,
                     painter = painter,
-                    size = size,
+                    size = iconSize,
                     tint = if (isSelected) selectedPinColor else color,
                 )
             }
@@ -134,8 +134,10 @@ private fun DrawScope.drawFindingPin(
     size: Float,
     tint: androidx.compose.ui.graphics.Color,
 ) {
-    val haloRadius = size / 2 + 3.dp.toPx()
-    val ringRadius = size / 2 + 1.dp.toPx()
+    // Use diagonal of icon square to calculate circle sizes (ensures full icon visibility)
+    val iconDiagonal = size * 1.41f / 2
+    val haloRadius = iconDiagonal + 3.dp.toPx()
+    val ringRadius = iconDiagonal + 1.dp.toPx()
 
     // Draw white halo (outermost layer)
     drawCircle(


### PR DESCRIPTION
## Summary
- Increase floor plan icon size from 24dp/32dp to 28dp/36dp (normal/selected)
- Calculate halo/ring radii based on icon diagonal (√2 ≈ 1.41x) to ensure full icon visibility
- Prevents clipping of icon details like the X (unvisited) and pencil (note)

## Problem
The previous implementation sized the circular backgrounds based on half the icon size (`size / 2`), which works for perfectly circular icons but clips square icons where details extend to corners (like the X in `wrong_location` or pencil in `edit_location_alt`).

## Solution
Use the diagonal of the square icon (`size * 1.41 / 2`) as the base radius, ensuring the circles fully contain the icon even at its widest points (the corners).

## Test plan
- [ ] Run desktop app, view floor plan with all three finding types
- [ ] Verify unvisited icon (X) is not clipped
- [ ] Verify note icon (pencil) is not clipped
- [ ] Verify classic icon (pin) displays correctly
- [ ] Verify both normal and selected sizes work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)