### PR TITLE
Extract generic driven implementation base classes

### DIFF
--- a/feat/clients/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/clients/fe/driven/di/ClientsDrivenModule.kt
+++ b/feat/clients/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/clients/fe/driven/di/ClientsDrivenModule.kt
@@ -33,7 +33,7 @@ val clientsDrivenModule =
     module {
         factory {
             RealClientsDb(
-                clientEntityQueries = get(),
+                queries = get(),
                 ioDispatcher = getIoDispatcher(),
             )
         } bind ClientsDb::class

--- a/feat/projects/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driven/di/ProjectsDrivenModule.kt
+++ b/feat/projects/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driven/di/ProjectsDrivenModule.kt
@@ -33,7 +33,7 @@ val projectsDrivenModule =
     module {
         factory {
             RealProjectsDb(
-                projectEntityQueries = get(),
+                queries = get(),
                 ioDispatcher = getIoDispatcher(),
             )
         } bind ProjectsDb::class

--- a/feat/projects/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driven/internal/db/RealProjectsDb.kt
+++ b/feat/projects/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driven/internal/db/RealProjectsDb.kt
@@ -12,68 +12,48 @@
 
 package cz.adamec.timotej.snag.projects.fe.driven.internal.db
 
-import app.cash.sqldelight.coroutines.asFlow
-import app.cash.sqldelight.coroutines.mapToList
-import app.cash.sqldelight.coroutines.mapToOneOrNull
 import cz.adamec.timotej.snag.feat.shared.database.fe.db.ProjectEntity
 import cz.adamec.timotej.snag.feat.shared.database.fe.db.ProjectEntityQueries
-import cz.adamec.timotej.snag.lib.core.fe.OfflineFirstDataResult
-import cz.adamec.timotej.snag.lib.database.fe.safeDbWrite
+import cz.adamec.timotej.snag.lib.database.fe.SqlDelightEntityDb
 import cz.adamec.timotej.snag.projects.fe.driven.internal.LH
 import cz.adamec.timotej.snag.projects.fe.model.FrontendProject
 import cz.adamec.timotej.snag.projects.fe.ports.ProjectsDb
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.map
 import kotlin.uuid.Uuid
 
+@Suppress("TooManyFunctions")
 internal class RealProjectsDb(
-    private val projectEntityQueries: ProjectEntityQueries,
-    private val ioDispatcher: CoroutineDispatcher,
-) : ProjectsDb {
-    override fun getAllProjectsFlow(): Flow<OfflineFirstDataResult<List<FrontendProject>>> =
-        projectEntityQueries
-            .selectAll()
-            .asFlow()
-            .mapToList(ioDispatcher)
-            .map<List<ProjectEntity>, OfflineFirstDataResult<List<FrontendProject>>> { entities ->
-                OfflineFirstDataResult.Success(
-                    entities.map { it.toModel() },
-                )
-            }.catch { e ->
-                LH.logger.e { "Error loading projects from DB." }
-                emit(OfflineFirstDataResult.ProgrammerError(throwable = e))
-            }
+    private val queries: ProjectEntityQueries,
+    ioDispatcher: CoroutineDispatcher,
+) : SqlDelightEntityDb<ProjectEntity, FrontendProject>(ioDispatcher, LH.logger, "project"),
+    ProjectsDb {
+    override fun selectAllQuery() = queries.selectAll()
 
-    override suspend fun saveProjects(projects: List<FrontendProject>): OfflineFirstDataResult<Unit> =
-        safeDbWrite(ioDispatcher = ioDispatcher, logger = LH.logger, errorMessage = "Error saving projects $projects to DB.") {
-            projectEntityQueries.transaction {
-                projects.forEach {
-                    projectEntityQueries.save(it.toEntity())
-                }
-            }
-        }
+    override fun selectByIdQuery(id: String) = queries.selectById(id)
 
-    override fun getProjectFlow(id: Uuid): Flow<OfflineFirstDataResult<FrontendProject?>> =
-        projectEntityQueries
-            .selectById(id.toString())
-            .asFlow()
-            .mapToOneOrNull(ioDispatcher)
-            .map<ProjectEntity?, OfflineFirstDataResult<FrontendProject?>> {
-                OfflineFirstDataResult.Success(it?.toModel())
-            }.catch { e ->
-                LH.logger.e { "Error loading project $id from DB." }
-                emit(OfflineFirstDataResult.ProgrammerError(throwable = e))
-            }
+    override suspend fun saveEntity(entity: ProjectEntity) {
+        queries.save(entity)
+    }
 
-    override suspend fun saveProject(project: FrontendProject): OfflineFirstDataResult<Unit> =
-        safeDbWrite(ioDispatcher = ioDispatcher, logger = LH.logger, errorMessage = "Error saving project $project to DB.") {
-            projectEntityQueries.save(project.toEntity())
-        }
+    override suspend fun deleteEntityById(id: String) {
+        queries.deleteById(id)
+    }
 
-    override suspend fun deleteProject(id: Uuid): OfflineFirstDataResult<Unit> =
-        safeDbWrite(ioDispatcher = ioDispatcher, logger = LH.logger, errorMessage = "Error deleting project $id from DB.") {
-            projectEntityQueries.deleteById(id.toString())
-        }
+    override suspend fun runInTransaction(block: suspend () -> Unit) {
+        queries.transaction { block() }
+    }
+
+    override fun mapToModel(entity: ProjectEntity) = entity.toModel()
+
+    override fun mapToEntity(model: FrontendProject) = model.toEntity()
+
+    override fun getAllProjectsFlow() = allEntitiesFlow()
+
+    override fun getProjectFlow(id: Uuid) = entityByIdFlow(id)
+
+    override suspend fun saveProject(project: FrontendProject) = saveOne(project)
+
+    override suspend fun saveProjects(projects: List<FrontendProject>) = saveMany(projects)
+
+    override suspend fun deleteProject(id: Uuid) = deleteById(id)
 }

--- a/feat/projects/fe/driven/test/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driven/test/FakeProjectsApi.kt
+++ b/feat/projects/fe/driven/test/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driven/test/FakeProjectsApi.kt
@@ -13,57 +13,35 @@
 package cz.adamec.timotej.snag.projects.fe.driven.test
 
 import cz.adamec.timotej.snag.lib.core.common.Timestamp
-import cz.adamec.timotej.snag.lib.core.fe.OnlineDataResult
+import cz.adamec.timotej.snag.lib.core.fe.test.FakeEntityApi
 import cz.adamec.timotej.snag.projects.fe.model.FrontendProject
 import cz.adamec.timotej.snag.projects.fe.ports.ProjectSyncResult
 import cz.adamec.timotej.snag.projects.fe.ports.ProjectsApi
 import kotlin.uuid.Uuid
 
-class FakeProjectsApi : ProjectsApi {
-    private val projects = mutableMapOf<Uuid, FrontendProject>()
-    var forcedFailure: OnlineDataResult.Failure? = null
-    var saveProjectResponseOverride: ((FrontendProject) -> OnlineDataResult<FrontendProject?>)? = null
-    var modifiedSinceResults: List<ProjectSyncResult> = emptyList()
-
-    override suspend fun getProjects(): OnlineDataResult<List<FrontendProject>> {
-        val failure = forcedFailure
-        if (failure != null) return failure
-        return OnlineDataResult.Success(projects.values.toList())
-    }
-
-    override suspend fun getProject(id: Uuid): OnlineDataResult<FrontendProject> {
-        val failure = forcedFailure
-        if (failure != null) return failure
-        return projects[id]?.let { OnlineDataResult.Success(it) }
-            ?: OnlineDataResult.Failure.ProgrammerError(Exception("Not found"))
-    }
-
-    override suspend fun saveProject(project: FrontendProject): OnlineDataResult<FrontendProject?> {
-        val failure = forcedFailure
-        if (failure != null) return failure
-        val override = saveProjectResponseOverride
-        return if (override != null) {
-            override(project)
-        } else {
-            projects[project.project.id] = project
-            OnlineDataResult.Success(project)
+class FakeProjectsApi :
+    FakeEntityApi<FrontendProject, ProjectSyncResult>(
+        getId = { it.project.id },
+    ),
+    ProjectsApi {
+    var saveProjectResponseOverride
+        get() = saveResponseOverride
+        set(value) {
+            saveResponseOverride = value
         }
-    }
 
-    override suspend fun deleteProject(id: Uuid, deletedAt: Timestamp): OnlineDataResult<Unit> {
-        val failure = forcedFailure
-        if (failure != null) return failure
-        projects.remove(id)
-        return OnlineDataResult.Success(Unit)
-    }
+    override suspend fun getProjects() = getAllItems()
 
-    override suspend fun getProjectsModifiedSince(since: Timestamp): OnlineDataResult<List<ProjectSyncResult>> {
-        val failure = forcedFailure
-        if (failure != null) return failure
-        return OnlineDataResult.Success(modifiedSinceResults)
-    }
+    override suspend fun getProject(id: Uuid) = getItemById(id)
 
-    fun setProject(project: FrontendProject) {
-        projects[project.project.id] = project
-    }
+    override suspend fun saveProject(project: FrontendProject) = saveItem(project)
+
+    override suspend fun deleteProject(
+        id: Uuid,
+        deletedAt: Timestamp,
+    ) = deleteItemById(id)
+
+    override suspend fun getProjectsModifiedSince(since: Timestamp) = getModifiedSinceItems()
+
+    fun setProject(project: FrontendProject) = setItem(project)
 }

--- a/feat/structures/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driven/di/StructuresDrivenModule.kt
+++ b/feat/structures/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driven/di/StructuresDrivenModule.kt
@@ -33,7 +33,7 @@ val structuresDrivenModule =
     module {
         factory {
             RealStructuresDb(
-                structureEntityQueries = get(),
+                queries = get(),
                 ioDispatcher = getIoDispatcher(),
             )
         } bind StructuresDb::class

--- a/feat/structures/fe/driven/test/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driven/test/FakeStructuresApi.kt
+++ b/feat/structures/fe/driven/test/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driven/test/FakeStructuresApi.kt
@@ -14,53 +14,37 @@ package cz.adamec.timotej.snag.structures.fe.driven.test
 
 import cz.adamec.timotej.snag.feat.structures.fe.model.FrontendStructure
 import cz.adamec.timotej.snag.lib.core.common.Timestamp
-import cz.adamec.timotej.snag.lib.core.fe.OnlineDataResult
+import cz.adamec.timotej.snag.lib.core.fe.test.FakeEntityApi
 import cz.adamec.timotej.snag.structures.fe.ports.StructureSyncResult
 import cz.adamec.timotej.snag.structures.fe.ports.StructuresApi
 import kotlin.uuid.Uuid
 
-class FakeStructuresApi : StructuresApi {
-    private val structures = mutableMapOf<Uuid, FrontendStructure>()
-    var forcedFailure: OnlineDataResult.Failure? = null
-    var saveStructureResponseOverride: ((FrontendStructure) -> OnlineDataResult<FrontendStructure?>)? = null
-    var modifiedSinceResults: List<StructureSyncResult> = emptyList()
-
-    override suspend fun getStructures(projectId: Uuid): OnlineDataResult<List<FrontendStructure>> {
-        val failure = forcedFailure
-        if (failure != null) return failure
-        return OnlineDataResult.Success(structures.values.filter { it.structure.projectId == projectId })
-    }
-
-    override suspend fun deleteStructure(id: Uuid, deletedAt: Timestamp): OnlineDataResult<Unit> {
-        val failure = forcedFailure
-        if (failure != null) return failure
-        structures.remove(id)
-        return OnlineDataResult.Success(Unit)
-    }
-
-    override suspend fun saveStructure(frontendStructure: FrontendStructure): OnlineDataResult<FrontendStructure?> {
-        val failure = forcedFailure
-        if (failure != null) return failure
-        val override = saveStructureResponseOverride
-        return if (override != null) {
-            override(frontendStructure)
-        } else {
-            structures[frontendStructure.structure.id] = frontendStructure
-            OnlineDataResult.Success(frontendStructure)
+class FakeStructuresApi :
+    FakeEntityApi<FrontendStructure, StructureSyncResult>(
+        getId = { it.structure.id },
+    ),
+    StructuresApi {
+    var saveStructureResponseOverride
+        get() = saveResponseOverride
+        set(value) {
+            saveResponseOverride = value
         }
-    }
 
-    fun setStructure(structure: FrontendStructure) {
-        structures[structure.structure.id] = structure
-    }
+    override suspend fun getStructures(projectId: Uuid) = getAllItems { it.structure.projectId == projectId }
 
-    override suspend fun getStructuresModifiedSince(projectId: Uuid, since: Timestamp): OnlineDataResult<List<StructureSyncResult>> {
-        val failure = forcedFailure
-        if (failure != null) return failure
-        return OnlineDataResult.Success(modifiedSinceResults)
-    }
+    override suspend fun saveStructure(frontendStructure: FrontendStructure) = saveItem(frontendStructure)
 
-    fun setStructures(structures: List<FrontendStructure>) {
-        structures.forEach { this.structures[it.structure.id] = it }
-    }
+    override suspend fun deleteStructure(
+        id: Uuid,
+        deletedAt: Timestamp,
+    ) = deleteItemById(id)
+
+    override suspend fun getStructuresModifiedSince(
+        projectId: Uuid,
+        since: Timestamp,
+    ) = getModifiedSinceItems()
+
+    fun setStructure(structure: FrontendStructure) = setItem(structure)
+
+    fun setStructures(structures: List<FrontendStructure>) = setItems(structures)
 }

--- a/feat/structures/fe/driven/test/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driven/test/FakeStructuresDb.kt
+++ b/feat/structures/fe/driven/test/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driven/test/FakeStructuresDb.kt
@@ -13,77 +13,33 @@
 package cz.adamec.timotej.snag.structures.fe.driven.test
 
 import cz.adamec.timotej.snag.feat.structures.fe.model.FrontendStructure
-import cz.adamec.timotej.snag.lib.core.fe.OfflineFirstDataResult
+import cz.adamec.timotej.snag.lib.core.fe.test.FakeEntityDb
 import cz.adamec.timotej.snag.structures.fe.ports.StructuresDb
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.update
 import kotlin.uuid.Uuid
 
-class FakeStructuresDb : StructuresDb {
-    private val structures = MutableStateFlow<Map<Uuid, FrontendStructure>>(emptyMap())
-    var forcedFailure: OfflineFirstDataResult.ProgrammerError? = null
+class FakeStructuresDb :
+    FakeEntityDb<FrontendStructure>(
+        getId = { it.structure.id },
+    ),
+    StructuresDb {
+    override fun getStructuresFlow(projectId: Uuid) = allItemsFlow { it.structure.projectId == projectId }
 
-    override fun getStructuresFlow(projectId: Uuid): Flow<OfflineFirstDataResult<List<FrontendStructure>>> =
-        structures.map { map ->
-            val failure = forcedFailure
-            failure ?: OfflineFirstDataResult.Success(map.values.filter { it.structure.projectId == projectId })
-        }
+    override fun getStructureFlow(id: Uuid) = itemByIdFlow(id)
 
-    override suspend fun saveStructures(structures: List<FrontendStructure>): OfflineFirstDataResult<Unit> {
-        val failure = forcedFailure
-        if (failure != null) return failure
+    override suspend fun saveStructure(structure: FrontendStructure) = saveOneItem(structure)
 
-        this.structures.update { current ->
-            current + structures.associateBy { it.structure.id }
-        }
-        return OfflineFirstDataResult.Success(Unit)
-    }
+    override suspend fun saveStructures(structures: List<FrontendStructure>) = saveManyItems(structures)
 
-    override suspend fun saveStructure(structure: FrontendStructure): OfflineFirstDataResult<Unit> {
-        val failure = forcedFailure
-        if (failure != null) return failure
-
-        structures.update { it + (structure.structure.id to structure) }
-        return OfflineFirstDataResult.Success(Unit)
-    }
-
-    override suspend fun deleteStructure(id: Uuid): OfflineFirstDataResult<Unit> {
-        val failure = forcedFailure
-        if (failure != null) return failure
-
-        structures.update { it - id }
-        return OfflineFirstDataResult.Success(Unit)
-    }
-
-    override fun getStructureFlow(id: Uuid): Flow<OfflineFirstDataResult<FrontendStructure?>> =
-        structures.map { map ->
-            val failure = forcedFailure
-            if (failure != null) {
-                failure
-            } else {
-                OfflineFirstDataResult.Success(map[id])
-            }
-        }
+    override suspend fun deleteStructure(id: Uuid) = deleteItem(id)
 
     override suspend fun getStructureIdsByProjectId(projectId: Uuid): List<Uuid> =
-        structures.value.values.filter { it.structure.projectId == projectId }.map { it.structure.id }
+        items.value.values
+            .filter { it.structure.projectId == projectId }
+            .map { it.structure.id }
 
-    override suspend fun deleteStructuresByProjectId(projectId: Uuid): OfflineFirstDataResult<Unit> {
-        val failure = forcedFailure
-        if (failure != null) return failure
-        structures.update { current -> current.filterValues { it.structure.projectId != projectId } }
-        return OfflineFirstDataResult.Success(Unit)
-    }
+    override suspend fun deleteStructuresByProjectId(projectId: Uuid) = deleteItemsWhere { it.structure.projectId != projectId }
 
-    fun setStructure(structure: FrontendStructure) {
-        structures.update { it + (structure.structure.id to structure) }
-    }
+    fun setStructure(structure: FrontendStructure) = setItem(structure)
 
-    fun setStructures(structures: List<FrontendStructure>) {
-        this.structures.update { current ->
-            current + structures.associateBy { it.structure.id }
-        }
-    }
+    fun setStructures(structures: List<FrontendStructure>) = setItems(structures)
 }

--- a/lib/core/fe/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/core/fe/test/FakeEntityApi.kt
+++ b/lib/core/fe/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/core/fe/test/FakeEntityApi.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.lib.core.fe.test
+
+import cz.adamec.timotej.snag.lib.core.fe.OnlineDataResult
+import kotlin.uuid.Uuid
+
+abstract class FakeEntityApi<T, SyncResultType>(
+    private val getId: (T) -> Uuid,
+) {
+    protected val apiItems = mutableMapOf<Uuid, T>()
+    var forcedFailure: OnlineDataResult.Failure? = null
+    var saveResponseOverride: ((T) -> OnlineDataResult<T?>)? = null
+    var modifiedSinceResults: List<SyncResultType> = emptyList()
+
+    protected fun getAllItems(): OnlineDataResult<List<T>> {
+        val failure = forcedFailure
+        if (failure != null) return failure
+        return OnlineDataResult.Success(apiItems.values.toList())
+    }
+
+    protected fun getAllItems(filter: (T) -> Boolean): OnlineDataResult<List<T>> {
+        val failure = forcedFailure
+        if (failure != null) return failure
+        return OnlineDataResult.Success(apiItems.values.filter(filter))
+    }
+
+    protected fun getItemById(id: Uuid): OnlineDataResult<T> {
+        val failure = forcedFailure
+        if (failure != null) return failure
+        return apiItems[id]?.let { OnlineDataResult.Success(it) }
+            ?: OnlineDataResult.Failure.ProgrammerError(Exception("Not found"))
+    }
+
+    protected fun saveItem(item: T): OnlineDataResult<T?> {
+        val failure = forcedFailure
+        if (failure != null) return failure
+        val override = saveResponseOverride
+        return if (override != null) {
+            override(item)
+        } else {
+            apiItems[getId(item)] = item
+            OnlineDataResult.Success(item)
+        }
+    }
+
+    protected fun deleteItemById(id: Uuid): OnlineDataResult<Unit> {
+        val failure = forcedFailure
+        if (failure != null) return failure
+        apiItems.remove(id)
+        return OnlineDataResult.Success(Unit)
+    }
+
+    protected fun getModifiedSinceItems(): OnlineDataResult<List<SyncResultType>> {
+        val failure = forcedFailure
+        if (failure != null) return failure
+        return OnlineDataResult.Success(modifiedSinceResults)
+    }
+
+    fun setItem(item: T) {
+        apiItems[getId(item)] = item
+    }
+
+    fun setItems(newItems: List<T>) {
+        newItems.forEach { apiItems[getId(it)] = it }
+    }
+}

--- a/lib/core/fe/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/core/fe/test/FakeEntityDb.kt
+++ b/lib/core/fe/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/core/fe/test/FakeEntityDb.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.lib.core.fe.test
+
+import cz.adamec.timotej.snag.lib.core.fe.OfflineFirstDataResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlin.uuid.Uuid
+
+abstract class FakeEntityDb<T>(
+    private val getId: (T) -> Uuid,
+) {
+    protected val items = MutableStateFlow<Map<Uuid, T>>(emptyMap())
+    var forcedFailure: OfflineFirstDataResult.ProgrammerError? = null
+
+    protected fun allItemsFlow(): Flow<OfflineFirstDataResult<List<T>>> = items.map { OfflineFirstDataResult.Success(it.values.toList()) }
+
+    protected fun allItemsFlow(filter: (T) -> Boolean): Flow<OfflineFirstDataResult<List<T>>> =
+        items.map { map ->
+            val failure = forcedFailure
+            failure ?: OfflineFirstDataResult.Success(map.values.filter(filter))
+        }
+
+    protected fun itemByIdFlow(id: Uuid): Flow<OfflineFirstDataResult<T?>> =
+        items.map { map ->
+            val failure = forcedFailure
+            if (failure != null) {
+                failure
+            } else {
+                OfflineFirstDataResult.Success(map[id])
+            }
+        }
+
+    protected suspend fun saveOneItem(item: T): OfflineFirstDataResult<Unit> {
+        val failure = forcedFailure
+        if (failure != null) return failure
+
+        items.update { it + (getId(item) to item) }
+        return OfflineFirstDataResult.Success(Unit)
+    }
+
+    protected suspend fun saveManyItems(newItems: List<T>): OfflineFirstDataResult<Unit> {
+        val failure = forcedFailure
+        if (failure != null) return failure
+
+        items.update { current ->
+            current + newItems.associateBy { getId(it) }
+        }
+        return OfflineFirstDataResult.Success(Unit)
+    }
+
+    protected suspend fun deleteItem(id: Uuid): OfflineFirstDataResult<Unit> {
+        val failure = forcedFailure
+        if (failure != null) return failure
+
+        items.update { it - id }
+        return OfflineFirstDataResult.Success(Unit)
+    }
+
+    protected suspend fun deleteItemsWhere(keep: (T) -> Boolean): OfflineFirstDataResult<Unit> {
+        val failure = forcedFailure
+        if (failure != null) return failure
+
+        items.update { current -> current.filterValues(keep) }
+        return OfflineFirstDataResult.Success(Unit)
+    }
+
+    fun setItem(item: T) {
+        items.update { it + (getId(item) to item) }
+    }
+
+    fun setItems(newItems: List<T>) {
+        items.update { current ->
+            current + newItems.associateBy { getId(it) }
+        }
+    }
+}

--- a/lib/database/fe/build.gradle.kts
+++ b/lib/database/fe/build.gradle.kts
@@ -13,3 +13,12 @@
 plugins {
     alias(libs.plugins.snagFrontendMultiplatformModule)
 }
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.sqldelight.runtime)
+            implementation(libs.sqldelight.coroutines.extensions)
+        }
+    }
+}

--- a/lib/database/fe/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/database/fe/SqlDelightEntityDb.kt
+++ b/lib/database/fe/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/database/fe/SqlDelightEntityDb.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.lib.database.fe
+
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import app.cash.sqldelight.coroutines.mapToOneOrNull
+import co.touchlab.kermit.Logger
+import cz.adamec.timotej.snag.lib.core.fe.OfflineFirstDataResult
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import kotlin.uuid.Uuid
+
+@Suppress("TooManyFunctions")
+abstract class SqlDelightEntityDb<Entity : Any, Model>(
+    private val ioDispatcher: CoroutineDispatcher,
+    private val logger: Logger,
+    private val entityName: String,
+) {
+    protected open fun selectAllQuery(): Query<Entity> =
+        throw UnsupportedOperationException("selectAllQuery() not implemented for $entityName")
+
+    protected abstract fun selectByIdQuery(id: String): Query<Entity>
+
+    protected abstract suspend fun saveEntity(entity: Entity)
+
+    protected abstract suspend fun deleteEntityById(id: String)
+
+    protected abstract suspend fun runInTransaction(block: suspend () -> Unit)
+
+    protected abstract fun mapToModel(entity: Entity): Model
+
+    protected abstract fun mapToEntity(model: Model): Entity
+
+    protected fun allEntitiesFlow(): Flow<OfflineFirstDataResult<List<Model>>> =
+        selectAllQuery()
+            .asFlow()
+            .mapToList(ioDispatcher)
+            .map<List<Entity>, OfflineFirstDataResult<List<Model>>> { entities ->
+                OfflineFirstDataResult.Success(entities.map { mapToModel(it) })
+            }.catch { e ->
+                logger.e { "Error loading ${entityName}s from DB." }
+                emit(OfflineFirstDataResult.ProgrammerError(throwable = e))
+            }
+
+    protected fun entitiesByQueryFlow(query: Query<Entity>): Flow<OfflineFirstDataResult<List<Model>>> =
+        query
+            .asFlow()
+            .mapToList(ioDispatcher)
+            .map<List<Entity>, OfflineFirstDataResult<List<Model>>> { entities ->
+                OfflineFirstDataResult.Success(entities.map { mapToModel(it) })
+            }.catch { e ->
+                logger.e { "Error loading ${entityName}s from DB." }
+                emit(OfflineFirstDataResult.ProgrammerError(throwable = e))
+            }
+
+    protected fun entityByIdFlow(id: Uuid): Flow<OfflineFirstDataResult<Model?>> =
+        selectByIdQuery(id.toString())
+            .asFlow()
+            .mapToOneOrNull(ioDispatcher)
+            .map<Entity?, OfflineFirstDataResult<Model?>> {
+                OfflineFirstDataResult.Success(it?.let { mapToModel(it) })
+            }.catch { e ->
+                logger.e { "Error loading $entityName $id from DB." }
+                emit(OfflineFirstDataResult.ProgrammerError(throwable = e))
+            }
+
+    protected suspend fun saveOne(model: Model): OfflineFirstDataResult<Unit> =
+        safeDbWrite(
+            ioDispatcher = ioDispatcher,
+            logger = logger,
+            errorMessage = "Error saving $entityName to DB.",
+        ) {
+            saveEntity(mapToEntity(model))
+        }
+
+    protected suspend fun saveMany(models: List<Model>): OfflineFirstDataResult<Unit> =
+        safeDbWrite(
+            ioDispatcher = ioDispatcher,
+            logger = logger,
+            errorMessage = "Error saving ${entityName}s to DB.",
+        ) {
+            runInTransaction {
+                models.forEach { saveEntity(mapToEntity(it)) }
+            }
+        }
+
+    protected suspend fun deleteById(id: Uuid): OfflineFirstDataResult<Unit> =
+        safeDbWrite(
+            ioDispatcher = ioDispatcher,
+            logger = logger,
+            errorMessage = "Error deleting $entityName $id from DB.",
+        ) {
+            deleteEntityById(id.toString())
+        }
+
+    protected suspend fun deleteByQuery(
+        errorMessage: String,
+        block: suspend () -> Unit,
+    ): OfflineFirstDataResult<Unit> =
+        safeDbWrite(
+            ioDispatcher = ioDispatcher,
+            logger = logger,
+            errorMessage = errorMessage,
+        ) {
+            block()
+        }
+}


### PR DESCRIPTION
## Summary
- Extracted `SqlDelightEntityDb` base class in `lib/database/fe/` abstracting common CRUD patterns (flow queries, save, delete) from Real*Db implementations
- Extracted `FakeEntityDb` base class in `lib/core/fe/test/` abstracting MutableStateFlow-based storage from Fake*Db test doubles
- Extracted `FakeEntityApi` base class in `lib/core/fe/test/` abstracting in-memory map storage from Fake*Api test doubles
- Refactored RealProjectsDb, RealClientsDb, RealStructuresDb and all Fake*Db/Fake*Api across 4 features to use the new base classes
- RealFindingsDb left unchanged due to JOIN query complexity requiring different entity types

## Test plan
- [x] All existing tests pass unchanged (verified with `./gradlew jvmTest` for all feature modules)
- [x] ktlint passes on all modified modules
- [x] detekt passes on all modified modules
- [x] Full compilation succeeds across all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)