### PR TITLE
Move New buttons to contextual positions with inspection carousel

### DIFF
--- a/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetails/ui/ProjectDetailsContent.kt
+++ b/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetails/ui/ProjectDetailsContent.kt
@@ -255,7 +255,7 @@ private fun LoadedProjectDetailsContent(
                         contentAlignment = Alignment.TopCenter,
                     ) {
                         FlowRow(
-                            modifier = Modifier.widthIn(max = 936.dp),
+                            //modifier = Modifier.widthIn(max = 936.dp),
                             horizontalArrangement = Arrangement.spacedBy(12.dp),
                             verticalArrangement = Arrangement.spacedBy(12.dp),
                             maxItemsInEachRow = 3,

--- a/feat/structures/fe/driving/api/src/commonMain/kotlin/cz/adamec/timotej/snag/feat/structures/fe/driving/api/StructureCard.kt
+++ b/feat/structures/fe/driving/api/src/commonMain/kotlin/cz/adamec/timotej/snag/feat/structures/fe/driving/api/StructureCard.kt
@@ -46,7 +46,7 @@ fun StructureCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Card(
+    ElevatedCard(
         modifier = modifier,
         onClick = onClick,
     ) {


### PR DESCRIPTION
## Summary
- Removed the two "New" buttons from the top app bar to declutter it
- Inspections section now uses `HorizontalUncontainedCarousel` with a "New inspection" card as the first carousel item
- Structures section header now includes an inline "New structure" `AdaptiveTonalButton`
- Reordered sections: inspections first, then structures

## Test plan
- [ ] Build: `./gradlew :feat:projects:fe:driving:impl:build`
- [ ] Visual: top bar is clean (back button only)
- [ ] Visual: inspections carousel scrolls horizontally with "New" card first
- [ ] Visual: structures section has "New structure" button in header row
- [ ] Test narrow screens: carousel works, AdaptiveTonalButton collapses to icon-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)