### PR TITLE
Generalize impl and test auto-wiring to sibling api modules

### DIFF
--- a/build-logic/src/main/kotlin/cz/adamec/timotej/snag/buildsrc/configuration/BackendModuleSetup.kt
+++ b/build-logic/src/main/kotlin/cz/adamec/timotej/snag/buildsrc/configuration/BackendModuleSetup.kt
@@ -50,10 +50,14 @@ internal fun Project.configureBackendModule() {
             } else {
                 api(project("$businessDirectoryPath:business"))
             }
-        } else if (path.contains(":app:") && name == "impl") {
-            val feOrBeDirectoryPath = moduleDirectoryPath.substringBeforeLast(":app")
+        } else if (name == "impl" && hasFolderInPath(moduleDirectoryPath, "api")) {
             implementation(project("$moduleDirectoryPath:api"))
-            implementation(project("$feOrBeDirectoryPath:ports"))
+            if (path.contains(":app:")) {
+                val feOrBeDirectoryPath = moduleDirectoryPath.substringBeforeLast(":app")
+                implementation(project("$feOrBeDirectoryPath:ports"))
+            }
+        } else if (name == "test" && hasFolderInPath(moduleDirectoryPath, "api")) {
+            implementation(project("$moduleDirectoryPath:api"))
         } else if (path.contains("driven")) {
             val drivenDirectoryPath = moduleDirectoryPath.substringBeforeLast(":driven")
             api(project("$drivenDirectoryPath:ports"))

--- a/build-logic/src/main/kotlin/cz/adamec/timotej/snag/buildsrc/configuration/MultiplatformModuleSetup.kt
+++ b/build-logic/src/main/kotlin/cz/adamec/timotej/snag/buildsrc/configuration/MultiplatformModuleSetup.kt
@@ -126,12 +126,18 @@ internal fun Project.configureKotlinMultiplatformModule() {
                     } else {
                         api(project("$businessDirectoryPath:business"))
                     }
-                } else if (this@configureKotlinMultiplatformModule.path.contains(":app:") &&
-                    this@configureKotlinMultiplatformModule.name == "impl"
+                } else if (this@configureKotlinMultiplatformModule.name == "impl" &&
+                    hasFolderInPath(moduleDirectoryPath, "api")
                 ) {
-                    val feOrBeDirectoryPath = moduleDirectoryPath.substringBeforeLast(":app")
                     implementation(project("$moduleDirectoryPath:api"))
-                    implementation(project("$feOrBeDirectoryPath:ports"))
+                    if (this@configureKotlinMultiplatformModule.path.contains(":app:")) {
+                        val feOrBeDirectoryPath = moduleDirectoryPath.substringBeforeLast(":app")
+                        implementation(project("$feOrBeDirectoryPath:ports"))
+                    }
+                } else if (this@configureKotlinMultiplatformModule.name == "test" &&
+                    hasFolderInPath(moduleDirectoryPath, "api")
+                ) {
+                    implementation(project("$moduleDirectoryPath:api"))
                 } else if (this@configureKotlinMultiplatformModule.path.contains("driven")) {
                     val drivenDirectoryPath = moduleDirectoryPath.substringBeforeLast(":driven")
                     api(project("$drivenDirectoryPath:ports"))


### PR DESCRIPTION
## Summary
- Generalizes convention plugin auto-wiring so **any `impl` module** with a sibling `api` folder gets `implementation(project("...:api"))`, not just `app:impl`
- Adds auto-wiring for **`test` modules** with a sibling `api` folder
- Preserves existing `app:impl` → `:ports` dependency

## Affected modules (new auto-wiring)
- `fe/driving/impl` → `fe/driving/api` (clients, findings, structures, inspections)
- Any future `test` modules with a sibling `api`

## Test plan
- [x] `./gradlew build` compiles successfully (only pre-existing ktlint violation in `FakeDbOps.kt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)