### PR TITLE
Override toString() on Report to prevent binary data logging

### DIFF
--- a/feat/reports/business/src/commonMain/kotlin/cz/adamec/timotej/snag/reports/business/Report.kt
+++ b/feat/reports/business/src/commonMain/kotlin/cz/adamec/timotej/snag/reports/business/Report.kt
@@ -33,4 +33,7 @@ data class Report(
         result = 31 * result + bytes.contentHashCode()
         return result
     }
+
+    override fun toString(): String =
+        "Report(projectId=$projectId, fileName=$fileName, bytes=${bytes.size} bytes)"
 }


### PR DESCRIPTION
## Summary
- Overrides `toString()` on `Report` data class to display byte count instead of raw `ByteArray` contents
- Prevents PDF binary data from being dumped into logs when `OnlineDataResult.log()` is called during report download

## Test plan
- [x] `:feat:reports:business:jvmTest` — compilation check
- [x] `:feat:reports:fe:app:impl:jvmTest` — FE use case tests
- [x] `:feat:reports:be:app:impl:test` and `:feat:reports:be:driving:impl:test` — BE tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)