### PR TITLE
Draw finding coordinate markers on floor plan images in PDF reports

### DIFF
--- a/feat/reports/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/reports/be/driven/impl/internal/OpenPdfReportGenerator.kt
+++ b/feat/reports/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/reports/be/driven/impl/internal/OpenPdfReportGenerator.kt
@@ -14,6 +14,7 @@ package cz.adamec.timotej.snag.reports.be.driven.impl.internal
 
 import cz.adamec.timotej.snag.feat.findings.be.model.BackendFinding
 import cz.adamec.timotej.snag.feat.findings.business.FindingType
+import cz.adamec.timotej.snag.feat.findings.business.RelativeCoordinate
 import cz.adamec.timotej.snag.feat.structures.be.model.BackendStructure
 import cz.adamec.timotej.snag.reports.be.ports.PdfReportGenerator
 import cz.adamec.timotej.snag.reports.be.ports.ProjectReportData
@@ -27,12 +28,17 @@ import org.openpdf.text.Phrase
 import org.openpdf.text.pdf.PdfPCell
 import org.openpdf.text.pdf.PdfPTable
 import org.openpdf.text.pdf.PdfWriter
+import java.awt.BasicStroke
 import java.awt.Color
+import java.awt.RenderingHints
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.net.URI
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import javax.imageio.ImageIO
 
 internal class OpenPdfReportGenerator : PdfReportGenerator {
     override suspend fun generate(data: ProjectReportData): ByteArray {
@@ -151,7 +157,7 @@ internal class OpenPdfReportGenerator : PdfReportGenerator {
         document.add(Paragraph(structure.structure.name, FONT_HEADING))
         document.add(Paragraph("\n"))
 
-        addFloorPlan(document, structure)
+        addFloorPlan(document, structure, findings)
 
         if (findings.isEmpty()) {
             document.add(Paragraph("No findings for this structure.", FONT_NORMAL))
@@ -185,16 +191,33 @@ internal class OpenPdfReportGenerator : PdfReportGenerator {
     private fun addFloorPlan(
         document: Document,
         structure: BackendStructure,
+        findings: List<BackendFinding>,
     ) {
         val floorPlanUrl = structure.structure.floorPlanUrl ?: return
 
-        val image =
+        val imageBytes =
             try {
-                val bytes = URI(floorPlanUrl).toURL().readBytes()
-                Image.getInstance(bytes)
+                URI(floorPlanUrl).toURL().readBytes()
             } catch (e: Exception) {
                 document.add(Paragraph("Floor plan image could not be loaded.", FONT_SMALL))
                 LH.logger.warn("Floor plan image could not be loaded: $floorPlanUrl. Exception: $e")
+                return
+            }
+
+        val findingsWithCoordinates = findings.filter { it.finding.coordinates.isNotEmpty() }
+        val annotatedBytes =
+            if (findingsWithCoordinates.isNotEmpty()) {
+                drawFindingMarkers(imageBytes, findings)
+            } else {
+                imageBytes
+            }
+
+        val image =
+            try {
+                Image.getInstance(annotatedBytes)
+            } catch (e: Exception) {
+                document.add(Paragraph("Floor plan image could not be loaded.", FONT_SMALL))
+                LH.logger.warn("Floor plan image could not be rendered: $floorPlanUrl. Exception: $e")
                 return
             }
 
@@ -203,6 +226,81 @@ internal class OpenPdfReportGenerator : PdfReportGenerator {
         image.alignment = Element.ALIGN_CENTER
         document.add(image)
     }
+
+    private fun drawFindingMarkers(
+        imageBytes: ByteArray,
+        findings: List<BackendFinding>,
+    ): ByteArray {
+        val bufferedImage = ImageIO.read(ByteArrayInputStream(imageBytes))
+            ?: return imageBytes
+        val canvas = BufferedImage(
+            bufferedImage.width,
+            bufferedImage.height,
+            BufferedImage.TYPE_INT_ARGB,
+        )
+        val g = canvas.createGraphics()
+        g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+        g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
+        g.drawImage(bufferedImage, 0, 0, null)
+
+        val markerRadius = maxOf(canvas.width, canvas.height) / MARKER_RADIUS_DIVISOR
+        val fontSize = (markerRadius * MARKER_FONT_SCALE).toFloat()
+        g.font = g.font.deriveFont(java.awt.Font.BOLD, fontSize)
+
+        findings.forEachIndexed { index, backendFinding ->
+            val label = "${index + 1}"
+            val color = findingTypeColor(backendFinding.finding.type)
+            backendFinding.finding.coordinates.forEach { coord ->
+                drawMarker(g, coord, canvas.width, canvas.height, markerRadius, label, color)
+            }
+        }
+
+        g.dispose()
+
+        val output = ByteArrayOutputStream()
+        ImageIO.write(canvas, "png", output)
+        return output.toByteArray()
+    }
+
+    private fun drawMarker(
+        g: java.awt.Graphics2D,
+        coord: RelativeCoordinate,
+        imageWidth: Int,
+        imageHeight: Int,
+        radius: Int,
+        label: String,
+        color: Color,
+    ) {
+        val cx = (coord.x * imageWidth).toInt()
+        val cy = (coord.y * imageHeight).toInt()
+
+        // White halo
+        g.color = Color.WHITE
+        g.fillOval(cx - radius - MARKER_HALO_PX, cy - radius - MARKER_HALO_PX, (radius + MARKER_HALO_PX) * 2, (radius + MARKER_HALO_PX) * 2)
+
+        // Colored circle
+        g.color = color
+        g.fillOval(cx - radius, cy - radius, radius * 2, radius * 2)
+
+        // White border
+        g.color = Color.WHITE
+        g.stroke = BasicStroke(MARKER_BORDER_WIDTH)
+        g.drawOval(cx - radius, cy - radius, radius * 2, radius * 2)
+
+        // Number label
+        g.color = Color.WHITE
+        val fm = g.fontMetrics
+        val textWidth = fm.stringWidth(label)
+        val textHeight = fm.ascent
+        g.drawString(label, cx - textWidth / 2, cy + textHeight / 2 - fm.descent / 2)
+    }
+
+    private fun findingTypeColor(type: FindingType): Color =
+        when (type) {
+            is FindingType.Classic -> PIN_COLOR_CLASSIC
+            is FindingType.Note -> PIN_COLOR_NOTE
+            is FindingType.Unvisited -> PIN_COLOR_UNVISITED
+        }
 
     private fun addSummaryPage(
         document: Document,
@@ -287,5 +385,13 @@ internal class OpenPdfReportGenerator : PdfReportGenerator {
         private const val TABLE_COLUMNS_FINDINGS = 4
         private const val CELL_PADDING = 5f
         private const val FLOOR_PLAN_MAX_HEIGHT = 400f
+
+        private const val MARKER_RADIUS_DIVISOR = 60
+        private const val MARKER_FONT_SCALE = 1.2
+        private const val MARKER_HALO_PX = 2
+        private const val MARKER_BORDER_WIDTH = 2f
+        private val PIN_COLOR_CLASSIC = Color(186, 26, 26)
+        private val PIN_COLOR_NOTE = Color(98, 91, 113)
+        private val PIN_COLOR_UNVISITED = Color(121, 116, 126)
     }
 }


### PR DESCRIPTION
The report generator was embedding floor plan images as-is without
overlaying finding coordinate markers. Findings have RelativeCoordinate
data (x, y normalized to 0-1) that was only used in the interactive
Compose UI but ignored during PDF generation.

This uses Java AWT Graphics2D to draw numbered, color-coded markers on
floor plan images before embedding them in the PDF. Each marker number
corresponds to the finding's row number in the table below, enabling
cross-referencing. Marker colors match finding types (Classic=red,
Note=tertiary, Unvisited=outline).

https://claude.ai/code/session_01XQatTYrPTYxAdhozM7X2CQ