### PR TITLE
Add exponential backoff retry to Ktor HTTP client

### DIFF
--- a/lib/network/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/network/fe/driven/impl/di/NetworkDrivenModule.kt
+++ b/lib/network/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/network/fe/driven/impl/di/NetworkDrivenModule.kt
@@ -15,6 +15,7 @@ package cz.adamec.timotej.snag.network.fe.driven.impl.di
 import cz.adamec.timotej.snag.network.fe.driven.impl.internal.ContentNegotiationConfiguration
 import cz.adamec.timotej.snag.network.fe.driven.impl.internal.LoggingConfiguration
 import cz.adamec.timotej.snag.network.fe.driven.impl.internal.ResponseValidationConfiguration
+import cz.adamec.timotej.snag.network.fe.driven.impl.internal.RetryConfiguration
 import cz.adamec.timotej.snag.network.fe.ports.HttpClientConfiguration
 import io.ktor.client.HttpClient
 import org.koin.core.module.Module
@@ -30,6 +31,7 @@ val networkDrivenModule =
         singleOf(::LoggingConfiguration) bind HttpClientConfiguration::class
         singleOf(::ContentNegotiationConfiguration) bind HttpClientConfiguration::class
         singleOf(::ResponseValidationConfiguration) bind HttpClientConfiguration::class
+        singleOf(::RetryConfiguration) bind HttpClientConfiguration::class
         single {
             HttpClient {
                 getAll<HttpClientConfiguration>().forEach { configuration ->

--- a/lib/network/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/network/fe/driven/impl/internal/RetryConfiguration.kt
+++ b/lib/network/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/network/fe/driven/impl/internal/RetryConfiguration.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.network.fe.driven.impl.internal
+
+import cz.adamec.timotej.snag.network.fe.ports.HttpClientConfiguration
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.plugins.HttpRequestRetry
+
+internal class RetryConfiguration : HttpClientConfiguration {
+    override fun HttpClientConfig<*>.setup() {
+        install(HttpRequestRetry) {
+            retryOnServerErrors(maxRetries = 3)
+            retryOnException(maxRetries = 3, retryOnTimeout = true)
+            exponentialDelay()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `RetryConfiguration` implementing the existing `HttpClientConfiguration` pattern
- Retries up to 3 times on server errors (5xx) and network exceptions (including timeouts)
- Uses Ktor's built-in exponential delay (base 2s with jitter)

## Test plan
- [x] Build passes (`./gradlew :lib:network:fe:driven:impl:build`)
- [ ] Verify retry behavior on transient server errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)