### PR TITLE
Rename ExposedXxxDb to RealXxxDb

### DIFF
--- a/feat/clients/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/clients/be/driven/impl/di/ClientsDrivenModule.kt
+++ b/feat/clients/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/clients/be/driven/impl/di/ClientsDrivenModule.kt
@@ -12,7 +12,7 @@
 
 package cz.adamec.timotej.snag.clients.be.driven.impl.di
 
-import cz.adamec.timotej.snag.clients.be.driven.impl.internal.ExposedClientsDb
+import cz.adamec.timotej.snag.clients.be.driven.impl.internal.RealClientsDb
 import cz.adamec.timotej.snag.clients.be.ports.ClientsDb
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
@@ -20,5 +20,5 @@ import org.koin.dsl.module
 
 val clientsDrivenModule =
     module {
-        singleOf(::ExposedClientsDb) bind ClientsDb::class
+        singleOf(::RealClientsDb) bind ClientsDb::class
     }

--- a/feat/clients/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/clients/be/driven/impl/internal/RealClientsDb.kt
+++ b/feat/clients/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/clients/be/driven/impl/internal/RealClientsDb.kt
@@ -23,7 +23,7 @@ import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import kotlin.uuid.Uuid
 
-internal class ExposedClientsDb(
+internal class RealClientsDb(
     private val database: Database,
 ) : ClientsDb {
     override suspend fun getClients(): List<BackendClient> =

--- a/feat/findings/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/findings/be/driven/impl/di/FindingsDrivenModule.kt
+++ b/feat/findings/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/findings/be/driven/impl/di/FindingsDrivenModule.kt
@@ -12,7 +12,7 @@
 
 package cz.adamec.timotej.snag.findings.be.driven.impl.di
 
-import cz.adamec.timotej.snag.findings.be.driven.impl.internal.ExposedFindingsDb
+import cz.adamec.timotej.snag.findings.be.driven.impl.internal.RealFindingsDb
 import cz.adamec.timotej.snag.findings.be.ports.FindingsDb
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
@@ -20,5 +20,5 @@ import org.koin.dsl.module
 
 val findingsDrivenModule =
     module {
-        singleOf(::ExposedFindingsDb) bind FindingsDb::class
+        singleOf(::RealFindingsDb) bind FindingsDb::class
     }

--- a/feat/findings/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/findings/be/driven/impl/internal/RealFindingsDb.kt
+++ b/feat/findings/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/findings/be/driven/impl/internal/RealFindingsDb.kt
@@ -30,7 +30,7 @@ import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import kotlin.uuid.Uuid
 
-internal class ExposedFindingsDb(
+internal class RealFindingsDb(
     private val database: Database,
 ) : FindingsDb {
     override suspend fun getFindings(structureId: Uuid): List<BackendFinding> =

--- a/feat/findings/be/driven/impl/src/test/kotlin/cz/adamec/timotej/snag/findings/be/driven/impl/internal/RealFindingsDbFindingTypesTest.kt
+++ b/feat/findings/be/driven/impl/src/test/kotlin/cz/adamec/timotej/snag/findings/be/driven/impl/internal/RealFindingsDbFindingTypesTest.kt
@@ -33,7 +33,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.uuid.Uuid
 
-class ExposedFindingsDbFindingTypesTest : BackendKoinInitializedTest() {
+class RealFindingsDbFindingTypesTest : BackendKoinInitializedTest() {
     private val findingsDb: FindingsDb by inject()
     private val projectsDb: ProjectsDb by inject()
     private val structuresDb: StructuresDb by inject()

--- a/feat/inspections/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/feat/inspections/be/driven/impl/di/InspectionsDrivenModule.kt
+++ b/feat/inspections/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/feat/inspections/be/driven/impl/di/InspectionsDrivenModule.kt
@@ -12,7 +12,7 @@
 
 package cz.adamec.timotej.snag.feat.inspections.be.driven.impl.di
 
-import cz.adamec.timotej.snag.feat.inspections.be.driven.impl.internal.ExposedInspectionsDb
+import cz.adamec.timotej.snag.feat.inspections.be.driven.impl.internal.RealInspectionsDb
 import cz.adamec.timotej.snag.feat.inspections.be.ports.InspectionsDb
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
@@ -20,5 +20,5 @@ import org.koin.dsl.module
 
 val inspectionsDrivenModule =
     module {
-        singleOf(::ExposedInspectionsDb) bind InspectionsDb::class
+        singleOf(::RealInspectionsDb) bind InspectionsDb::class
     }

--- a/feat/inspections/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/feat/inspections/be/driven/impl/internal/RealInspectionsDb.kt
+++ b/feat/inspections/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/feat/inspections/be/driven/impl/internal/RealInspectionsDb.kt
@@ -26,7 +26,7 @@ import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import kotlin.uuid.Uuid
 
-internal class ExposedInspectionsDb(
+internal class RealInspectionsDb(
     private val database: Database,
 ) : InspectionsDb {
     override suspend fun getInspections(projectId: Uuid): List<BackendInspection> =

--- a/feat/projects/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/projects/be/driven/impl/di/ProjectsDrivenModule.kt
+++ b/feat/projects/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/projects/be/driven/impl/di/ProjectsDrivenModule.kt
@@ -12,7 +12,7 @@
 
 package cz.adamec.timotej.snag.projects.be.driven.impl.di
 
-import cz.adamec.timotej.snag.projects.be.driven.impl.internal.ExposedProjectsDb
+import cz.adamec.timotej.snag.projects.be.driven.impl.internal.RealProjectsDb
 import cz.adamec.timotej.snag.projects.be.ports.ProjectsDb
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
@@ -20,5 +20,5 @@ import org.koin.dsl.module
 
 val projectsDrivenModule =
     module {
-        singleOf(::ExposedProjectsDb) bind ProjectsDb::class
+        singleOf(::RealProjectsDb) bind ProjectsDb::class
     }

--- a/feat/projects/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/projects/be/driven/impl/internal/RealProjectsDb.kt
+++ b/feat/projects/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/projects/be/driven/impl/internal/RealProjectsDb.kt
@@ -24,7 +24,7 @@ import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import kotlin.uuid.Uuid
 
-internal class ExposedProjectsDb(
+internal class RealProjectsDb(
     private val database: Database,
 ) : ProjectsDb {
     override suspend fun getProjects(): List<BackendProject> =

--- a/feat/structures/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/structures/be/driven/impl/di/StructuresDrivenModule.kt
+++ b/feat/structures/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/structures/be/driven/impl/di/StructuresDrivenModule.kt
@@ -12,7 +12,7 @@
 
 package cz.adamec.timotej.snag.structures.be.driven.impl.di
 
-import cz.adamec.timotej.snag.structures.be.driven.impl.internal.ExposedStructuresDb
+import cz.adamec.timotej.snag.structures.be.driven.impl.internal.RealStructuresDb
 import cz.adamec.timotej.snag.structures.be.ports.StructuresDb
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
@@ -20,5 +20,5 @@ import org.koin.dsl.module
 
 val structuresDrivenModule =
     module {
-        singleOf(::ExposedStructuresDb) bind StructuresDb::class
+        singleOf(::RealStructuresDb) bind StructuresDb::class
     }

--- a/feat/structures/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/structures/be/driven/impl/internal/RealStructuresDb.kt
+++ b/feat/structures/be/driven/impl/src/main/kotlin/cz/adamec/timotej/snag/structures/be/driven/impl/internal/RealStructuresDb.kt
@@ -26,7 +26,7 @@ import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import kotlin.uuid.Uuid
 
-internal class ExposedStructuresDb(
+internal class RealStructuresDb(
     private val database: Database,
 ) : StructuresDb {
     override suspend fun getStructures(projectId: Uuid): List<BackendStructure> =


### PR DESCRIPTION
## Summary
- Renamed all `ExposedXxxDb` backend port implementations to `RealXxxDb` (Clients, Findings, Inspections, Projects, Structures)
- The "Exposed" prefix leaked the ORM implementation detail; "Real" is the conventional counterpart to "Fake"

## Test plan
- [x] Build compiles successfully
- [x] Existing backend tests pass (pre-existing ktlint violation in `FindingsRouteTest.kt` is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)