### PR TITLE
Optimize Gradle build performance

### DIFF
--- a/build-logic/src/main/kotlin/cz/adamec/timotej/snag/buildsrc/configuration/ComposeMultiplatformModuleSetup.kt
+++ b/build-logic/src/main/kotlin/cz/adamec/timotej/snag/buildsrc/configuration/ComposeMultiplatformModuleSetup.kt
@@ -17,13 +17,14 @@ import cz.adamec.timotej.snag.buildsrc.extensions.library
 import cz.adamec.timotej.snag.buildsrc.extensions.version
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.invoke
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 internal fun Project.configureComposeMultiplatformModule() {
 
     // Fixes a problem where skiko runtime has a different version than skiko-awt
-    configurations.all {
+    configurations.configureEach {
         resolutionStrategy.eachDependency {
             if (requested.group == "org.jetbrains.skiko") {
                 useVersion(version("skiko"))
@@ -87,6 +88,13 @@ internal fun Project.configureComposeMultiplatformModule() {
                 languageSettings.optIn("androidx.compose.material3.ExperimentalMaterial3Api")
                 languageSettings.optIn("androidx.compose.material3.ExperimentalMaterial3ExpressiveApi")
             }
+        }
+    }
+
+    dependencies {
+        val koinKspCompilerLib = library("koin-ksp-compiler")
+        configurations.matching { it.name.startsWith("ksp") && it.name != "ksp" }.configureEach {
+            add(this.name, koinKspCompilerLib)
         }
     }
 }

--- a/build-logic/src/main/kotlin/cz/adamec/timotej/snag/buildsrc/configuration/MultiplatformModuleSetup.kt
+++ b/build-logic/src/main/kotlin/cz/adamec/timotej/snag/buildsrc/configuration/MultiplatformModuleSetup.kt
@@ -18,7 +18,6 @@ import cz.adamec.timotej.snag.buildsrc.extensions.library
 import cz.adamec.timotej.snag.buildsrc.extensions.version
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.invoke
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
@@ -28,7 +27,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 internal fun Project.configureKotlinMultiplatformModule() {
 
     // Fixes a problem where kotlin stdlib has a different version than the compiler
-    configurations.all {
+    configurations.configureEach {
         resolutionStrategy.eachDependency {
             if (requested.group == "org.jetbrains.kotlin") {
                 useVersion(version("kotlin"))
@@ -171,7 +170,7 @@ internal fun Project.configureKotlinMultiplatformModule() {
                 implementation(library("kotlinx-coroutines-core"))
                 implementation(library("kotlinx-immutable-collections"))
                 implementation(library("koin-core"))
-                api(library("koin-annotations"))
+                implementation(library("koin-annotations"))
             }
             commonTest.dependencies {
                 implementation(library("kotlin-test"))
@@ -188,10 +187,4 @@ internal fun Project.configureKotlinMultiplatformModule() {
         }
     }
 
-    dependencies {
-        val koinKspCompilerLib = library("koin-ksp-compiler")
-        configurations.matching { it.name.startsWith("ksp") && it.name != "ksp" }.all {
-            add(this.name, koinKspCompilerLib)
-        }
-    }
 }

--- a/build-logic/src/main/kotlin/cz/adamec/timotej/snag/buildsrc/plugins/DrivingFrontendMultiplatformModulePlugin.kt
+++ b/build-logic/src/main/kotlin/cz/adamec/timotej/snag/buildsrc/plugins/DrivingFrontendMultiplatformModulePlugin.kt
@@ -25,6 +25,7 @@ class DrivingFrontendMultiplatformModulePlugin : Plugin<Project> {
         apply(plugin = pluginId("composeCompiler"))
         apply(plugin = pluginId("composeHotReload"))
         apply(plugin = pluginId("kotlinSerialization"))
+        apply(plugin = pluginId("ksp"))
         apply<FrontendMultiplatformModulePlugin>()
         configureComposeMultiplatformModule()
     }

--- a/build-logic/src/main/kotlin/cz/adamec/timotej/snag/buildsrc/plugins/MultiplatformModulePlugin.kt
+++ b/build-logic/src/main/kotlin/cz/adamec/timotej/snag/buildsrc/plugins/MultiplatformModulePlugin.kt
@@ -24,7 +24,6 @@ class MultiplatformModulePlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         apply(plugin = pluginId("kotlinMultiplatform"))
         apply(plugin = pluginId("androidKotlinMultiplatformLibrary"))
-        apply(plugin = pluginId("ksp"))
         configureKotlinMultiplatformModule()
         configureLint()
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ org.gradle.jvmargs=-Xmx16g -XX:MaxMetaspaceSize=4g
 org.gradle.configuration-cache=true
 org.gradle.caching=true
 org.gradle.parallel=true
-org.gradle.workers.max=4
+org.gradle.workers.max=8
 
 #Android
 android.nonTransitiveRClass=true


### PR DESCRIPTION
## Summary
- Increase `org.gradle.workers.max` from 4 to 8 to better utilize available CPU cores (14 cores on dev machine)
- Replace eager `configurations.all {}` with lazy `configurations.configureEach {}` in convention plugins to reduce configuration phase overhead
- Move KSP plugin + Koin KSP compiler from base `MultiplatformModulePlugin` (all ~58 KMP modules) to `DrivingFrontendMultiplatformModulePlugin` (only ~15 modules that actually use Koin annotations)

## Test plan
- [ ] `./gradlew build` succeeds with all targets and checks
- [ ] `./gradlew :feat:projects:fe:driving:impl:jvmTest` — tests pass (KSP still generates Koin modules in driving modules)
- [ ] Non-driving modules compile without KSP

🤖 Generated with [Claude Code](https://claude.com/claude-code)