### PR TITLE
Refactor soft-delete endpoints from DELETE to PATCH

### DIFF
--- a/feat/findings/be/driving/impl/src/main/kotlin/cz/adamec/timotej/snag/findings/be/driving/impl/internal/FindingsRoute.kt
+++ b/feat/findings/be/driving/impl/src/main/kotlin/cz/adamec/timotej/snag/findings/be/driving/impl/internal/FindingsRoute.kt
@@ -26,7 +26,7 @@ import cz.adamec.timotej.snag.routing.be.getIdFromParameters
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.delete
+import io.ktor.server.routing.patch
 import io.ktor.server.routing.get
 import io.ktor.server.routing.put
 import io.ktor.server.routing.route
@@ -40,7 +40,7 @@ internal class FindingsRoute(
 ) : AppRoute {
     override fun Route.setup() {
         route("/findings") {
-            delete("/{id}") {
+            patch("/{id}") {
                 val id = getIdFromParameters()
                 val deleteFindingDto = getDtoFromBody<DeleteFindingApiDto>()
 

--- a/feat/findings/be/driving/impl/src/test/kotlin/cz/adamec/timotej/snag/findings/be/driving/impl/internal/FindingsRouteTest.kt
+++ b/feat/findings/be/driving/impl/src/test/kotlin/cz/adamec/timotej/snag/findings/be/driving/impl/internal/FindingsRouteTest.kt
@@ -35,7 +35,7 @@ import cz.adamec.timotej.snag.projects.business.Project
 import cz.adamec.timotej.snag.structures.be.ports.StructuresDb
 import cz.adamec.timotej.snag.testinfra.be.BackendKoinInitializedTest
 import io.ktor.client.call.body
-import io.ktor.client.request.delete
+import io.ktor.client.request.patch
 import io.ktor.client.request.get
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
@@ -91,10 +91,10 @@ class FindingsRouteTest : BackendKoinInitializedTest() {
         }
     }
 
-    // region DELETE /findings/{id}
+    // region PATCH /findings/{id}
 
     @Test
-    fun `DELETE finding returns 204 when successfully deleted`() =
+    fun `PATCH soft-delete finding returns 204 when successfully deleted`() =
         testApplication {
             configureApp()
             seedParentEntities()
@@ -115,7 +115,7 @@ class FindingsRouteTest : BackendKoinInitializedTest() {
             val client = jsonClient()
 
             val response =
-                client.delete("/findings/$TEST_ID_1") {
+                client.patch("/findings/$TEST_ID_1") {
                     contentType(ContentType.Application.Json)
                     setBody(DeleteFindingApiDto(deletedAt = Timestamp(200L)))
                 }
@@ -124,7 +124,7 @@ class FindingsRouteTest : BackendKoinInitializedTest() {
         }
 
     @Test
-    fun `DELETE finding sets deletedAt on successful deletion`() =
+    fun `PATCH soft-delete finding sets deletedAt on successful deletion`() =
         testApplication {
             configureApp()
             seedParentEntities()
@@ -144,7 +144,7 @@ class FindingsRouteTest : BackendKoinInitializedTest() {
             )
             val client = jsonClient()
 
-            client.delete("/findings/$TEST_ID_1") {
+            client.patch("/findings/$TEST_ID_1") {
                 contentType(ContentType.Application.Json)
                 setBody(DeleteFindingApiDto(deletedAt = Timestamp(200L)))
             }
@@ -158,7 +158,7 @@ class FindingsRouteTest : BackendKoinInitializedTest() {
         }
 
     @Test
-    fun `DELETE finding returns existing finding on conflict`() =
+    fun `PATCH soft-delete finding returns existing finding on conflict`() =
         testApplication {
             configureApp()
             seedParentEntities()
@@ -179,7 +179,7 @@ class FindingsRouteTest : BackendKoinInitializedTest() {
             val client = jsonClient()
 
             val response =
-                client.delete("/findings/$TEST_ID_1") {
+                client.patch("/findings/$TEST_ID_1") {
                     contentType(ContentType.Application.Json)
                     setBody(DeleteFindingApiDto(deletedAt = Timestamp(200L)))
                 }
@@ -190,13 +190,13 @@ class FindingsRouteTest : BackendKoinInitializedTest() {
         }
 
     @Test
-    fun `DELETE finding with invalid id returns 400`() =
+    fun `PATCH soft-delete finding with invalid id returns 400`() =
         testApplication {
             configureApp()
             val client = jsonClient()
 
             val response =
-                client.delete("/findings/not-a-uuid") {
+                client.patch("/findings/not-a-uuid") {
                     contentType(ContentType.Application.Json)
                     setBody(DeleteFindingApiDto(deletedAt = Timestamp(200L)))
                 }
@@ -205,13 +205,13 @@ class FindingsRouteTest : BackendKoinInitializedTest() {
         }
 
     @Test
-    fun `DELETE finding with invalid body returns 400`() =
+    fun `PATCH soft-delete finding with invalid body returns 400`() =
         testApplication {
             configureApp()
             val client = jsonClient()
 
             val response =
-                client.delete("/findings/$TEST_ID_1") {
+                client.patch("/findings/$TEST_ID_1") {
                     contentType(ContentType.Application.Json)
                     setBody("{\"invalid\": true}")
                 }

--- a/feat/findings/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driven/internal/api/RealFindingsApi.kt
+++ b/feat/findings/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driven/internal/api/RealFindingsApi.kt
@@ -45,7 +45,7 @@ internal class RealFindingsApi(
     ): OnlineDataResult<Unit> {
         LH.logger.d { "Deleting finding $id from API..." }
         return safeApiCall(logger = LH.logger, errorContext = "Error deleting finding $id from API.") {
-            httpClient.delete("/findings/$id") {
+            httpClient.patch("/findings/$id") {
                 setBody(DeleteFindingApiDto(deletedAt = deletedAt))
             }
             Unit

--- a/feat/projects/be/driving/impl/src/main/kotlin/cz/adamec/timotej/snag/projects/be/driving/impl/internal/ProjectsRoute.kt
+++ b/feat/projects/be/driving/impl/src/main/kotlin/cz/adamec/timotej/snag/projects/be/driving/impl/internal/ProjectsRoute.kt
@@ -27,7 +27,7 @@ import cz.adamec.timotej.snag.routing.be.getIdFromParameters
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.delete
+import io.ktor.server.routing.patch
 import io.ktor.server.routing.get
 import io.ktor.server.routing.put
 import io.ktor.server.routing.route
@@ -79,7 +79,7 @@ internal class ProjectsRoute(
                 } ?: call.respond(HttpStatusCode.NoContent)
             }
 
-            delete("/{id}") {
+            patch("/{id}") {
                 val id = getIdFromParameters()
                 val deleteProjectDto = getDtoFromBody<DeleteProjectApiDto>()
 

--- a/feat/projects/be/driving/impl/src/test/kotlin/cz/adamec/timotej/snag/projects/be/driving/impl/internal/ProjectsRouteTest.kt
+++ b/feat/projects/be/driving/impl/src/test/kotlin/cz/adamec/timotej/snag/projects/be/driving/impl/internal/ProjectsRouteTest.kt
@@ -23,7 +23,7 @@ import cz.adamec.timotej.snag.projects.be.ports.ProjectsDb
 import cz.adamec.timotej.snag.projects.business.Project
 import cz.adamec.timotej.snag.testinfra.be.BackendKoinInitializedTest
 import io.ktor.client.call.body
-import io.ktor.client.request.delete
+import io.ktor.client.request.patch
 import io.ktor.client.request.get
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
@@ -378,7 +378,7 @@ class ProjectsRouteTest : BackendKoinInitializedTest() {
         }
 
     @Test
-    fun `DELETE project returns 204 when successfully deleted`() =
+    fun `PATCH soft-delete project returns 204 when successfully deleted`() =
         testApplication {
             configureApp()
             dataSource.saveProject(
@@ -395,7 +395,7 @@ class ProjectsRouteTest : BackendKoinInitializedTest() {
             val client = jsonClient()
 
             val response =
-                client.delete("/projects/$TEST_ID_1") {
+                client.patch("/projects/$TEST_ID_1") {
                     contentType(ContentType.Application.Json)
                     setBody(DeleteProjectApiDto(deletedAt = Timestamp(200L)))
                 }
@@ -404,7 +404,7 @@ class ProjectsRouteTest : BackendKoinInitializedTest() {
         }
 
     @Test
-    fun `DELETE project sets deletedAt on successful deletion`() =
+    fun `PATCH soft-delete project sets deletedAt on successful deletion`() =
         testApplication {
             configureApp()
             dataSource.saveProject(
@@ -420,7 +420,7 @@ class ProjectsRouteTest : BackendKoinInitializedTest() {
             )
             val client = jsonClient()
 
-            client.delete("/projects/$TEST_ID_1") {
+            client.patch("/projects/$TEST_ID_1") {
                 contentType(ContentType.Application.Json)
                 setBody(DeleteProjectApiDto(deletedAt = Timestamp(200L)))
             }
@@ -433,7 +433,7 @@ class ProjectsRouteTest : BackendKoinInitializedTest() {
         }
 
     @Test
-    fun `DELETE project returns existing project on conflict`() =
+    fun `PATCH soft-delete project returns existing project on conflict`() =
         testApplication {
             configureApp()
             dataSource.saveProject(
@@ -450,7 +450,7 @@ class ProjectsRouteTest : BackendKoinInitializedTest() {
             val client = jsonClient()
 
             val response =
-                client.delete("/projects/$TEST_ID_1") {
+                client.patch("/projects/$TEST_ID_1") {
                     contentType(ContentType.Application.Json)
                     setBody(DeleteProjectApiDto(deletedAt = Timestamp(200L)))
                 }
@@ -461,13 +461,13 @@ class ProjectsRouteTest : BackendKoinInitializedTest() {
         }
 
     @Test
-    fun `DELETE project with invalid id returns 400`() =
+    fun `PATCH soft-delete project with invalid id returns 400`() =
         testApplication {
             configureApp()
             val client = jsonClient()
 
             val response =
-                client.delete("/projects/not-a-uuid") {
+                client.patch("/projects/not-a-uuid") {
                     contentType(ContentType.Application.Json)
                     setBody(DeleteProjectApiDto(deletedAt = Timestamp(200L)))
                 }
@@ -476,13 +476,13 @@ class ProjectsRouteTest : BackendKoinInitializedTest() {
         }
 
     @Test
-    fun `DELETE project with invalid body returns 400`() =
+    fun `PATCH soft-delete project with invalid body returns 400`() =
         testApplication {
             configureApp()
             val client = jsonClient()
 
             val response =
-                client.delete("/projects/$TEST_ID_1") {
+                client.patch("/projects/$TEST_ID_1") {
                     contentType(ContentType.Application.Json)
                     setBody("{\"invalid\": true}")
                 }

--- a/feat/projects/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driven/internal/api/RealProjectsApi.kt
+++ b/feat/projects/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driven/internal/api/RealProjectsApi.kt
@@ -68,7 +68,7 @@ internal class RealProjectsApi(
     ): OnlineDataResult<Unit> {
         LH.logger.d { "Deleting project $id from API..." }
         return safeApiCall(logger = LH.logger, errorContext = "Error deleting project $id from API.") {
-            httpClient.delete("/projects/$id") {
+            httpClient.patch("/projects/$id") {
                 setBody(DeleteProjectApiDto(deletedAt = deletedAt))
             }
             Unit

--- a/feat/structures/be/driving/impl/src/main/kotlin/cz/adamec/timotej/snag/structures/be/driving/impl/internal/StructuresRoute.kt
+++ b/feat/structures/be/driving/impl/src/main/kotlin/cz/adamec/timotej/snag/structures/be/driving/impl/internal/StructuresRoute.kt
@@ -26,7 +26,7 @@ import cz.adamec.timotej.snag.structures.be.driving.contract.PutStructureApiDto
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.delete
+import io.ktor.server.routing.patch
 import io.ktor.server.routing.get
 import io.ktor.server.routing.put
 import io.ktor.server.routing.route
@@ -40,7 +40,7 @@ internal class StructuresRoute(
 ) : AppRoute {
     override fun Route.setup() {
         route("/structures") {
-            delete("/{id}") {
+            patch("/{id}") {
                 val id = getIdFromParameters()
                 val deleteStructureDto = getDtoFromBody<DeleteStructureApiDto>()
 

--- a/feat/structures/be/driving/impl/src/test/kotlin/cz/adamec/timotej/snag/structures/be/driving/impl/internal/StructuresRouteTest.kt
+++ b/feat/structures/be/driving/impl/src/test/kotlin/cz/adamec/timotej/snag/structures/be/driving/impl/internal/StructuresRouteTest.kt
@@ -26,7 +26,7 @@ import cz.adamec.timotej.snag.structures.be.driving.contract.StructureApiDto
 import cz.adamec.timotej.snag.structures.be.ports.StructuresDb
 import cz.adamec.timotej.snag.testinfra.be.BackendKoinInitializedTest
 import io.ktor.client.call.body
-import io.ktor.client.request.delete
+import io.ktor.client.request.patch
 import io.ktor.client.request.get
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
@@ -69,10 +69,10 @@ class StructuresRouteTest : BackendKoinInitializedTest() {
         }
     }
 
-    // region DELETE /structures/{id}
+    // region PATCH /structures/{id}
 
     @Test
-    fun `DELETE structure returns 204 when successfully deleted`() =
+    fun `PATCH soft-delete structure returns 204 when successfully deleted`() =
         testApplication {
             configureApp()
             createParentProject()
@@ -91,7 +91,7 @@ class StructuresRouteTest : BackendKoinInitializedTest() {
             val client = jsonClient()
 
             val response =
-                client.delete("/structures/$TEST_ID_1") {
+                client.patch("/structures/$TEST_ID_1") {
                     contentType(ContentType.Application.Json)
                     setBody(DeleteStructureApiDto(deletedAt = Timestamp(200L)))
                 }
@@ -100,7 +100,7 @@ class StructuresRouteTest : BackendKoinInitializedTest() {
         }
 
     @Test
-    fun `DELETE structure sets deletedAt on successful deletion`() =
+    fun `PATCH soft-delete structure sets deletedAt on successful deletion`() =
         testApplication {
             configureApp()
             createParentProject()
@@ -118,7 +118,7 @@ class StructuresRouteTest : BackendKoinInitializedTest() {
             )
             val client = jsonClient()
 
-            client.delete("/structures/$TEST_ID_1") {
+            client.patch("/structures/$TEST_ID_1") {
                 contentType(ContentType.Application.Json)
                 setBody(DeleteStructureApiDto(deletedAt = Timestamp(200L)))
             }
@@ -132,7 +132,7 @@ class StructuresRouteTest : BackendKoinInitializedTest() {
         }
 
     @Test
-    fun `DELETE structure returns existing structure on conflict`() =
+    fun `PATCH soft-delete structure returns existing structure on conflict`() =
         testApplication {
             configureApp()
             createParentProject()
@@ -151,7 +151,7 @@ class StructuresRouteTest : BackendKoinInitializedTest() {
             val client = jsonClient()
 
             val response =
-                client.delete("/structures/$TEST_ID_1") {
+                client.patch("/structures/$TEST_ID_1") {
                     contentType(ContentType.Application.Json)
                     setBody(DeleteStructureApiDto(deletedAt = Timestamp(200L)))
                 }
@@ -162,13 +162,13 @@ class StructuresRouteTest : BackendKoinInitializedTest() {
         }
 
     @Test
-    fun `DELETE structure with invalid id returns 400`() =
+    fun `PATCH soft-delete structure with invalid id returns 400`() =
         testApplication {
             configureApp()
             val client = jsonClient()
 
             val response =
-                client.delete("/structures/not-a-uuid") {
+                client.patch("/structures/not-a-uuid") {
                     contentType(ContentType.Application.Json)
                     setBody(DeleteStructureApiDto(deletedAt = Timestamp(200L)))
                 }
@@ -177,13 +177,13 @@ class StructuresRouteTest : BackendKoinInitializedTest() {
         }
 
     @Test
-    fun `DELETE structure with invalid body returns 400`() =
+    fun `PATCH soft-delete structure with invalid body returns 400`() =
         testApplication {
             configureApp()
             val client = jsonClient()
 
             val response =
-                client.delete("/structures/$TEST_ID_1") {
+                client.patch("/structures/$TEST_ID_1") {
                     contentType(ContentType.Application.Json)
                     setBody("{\"invalid\": true}")
                 }

--- a/feat/structures/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driven/internal/api/RealStructuresApi.kt
+++ b/feat/structures/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driven/internal/api/RealStructuresApi.kt
@@ -45,7 +45,7 @@ internal class RealStructuresApi(
     ): OnlineDataResult<Unit> {
         LH.logger.d { "Deleting structure $id from API..." }
         return safeApiCall(logger = LH.logger, errorContext = "Error deleting structure $id from API.") {
-            httpClient.delete("/structures/$id") {
+            httpClient.patch("/structures/$id") {
                 setBody(DeleteStructureApiDto(deletedAt = deletedAt))
             }
             Unit

--- a/lib/network/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/network/fe/SnagNetworkHttpClient.kt
+++ b/lib/network/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/network/fe/SnagNetworkHttpClient.kt
@@ -34,6 +34,12 @@ interface SnagNetworkHttpClient {
         block: HttpRequestBuilder.() -> Unit = {},
     ): HttpResponse
 
+    suspend fun patch(
+        path: String,
+        contentType: ContentType = ContentType.Application.Json,
+        block: HttpRequestBuilder.() -> Unit = {},
+    ): HttpResponse
+
     suspend fun delete(
         path: String,
         contentType: ContentType = ContentType.Application.Json,

--- a/lib/network/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/network/fe/app/impl/internal/SnagNetworkHttpClientImpl.kt
+++ b/lib/network/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/network/fe/app/impl/internal/SnagNetworkHttpClientImpl.kt
@@ -17,6 +17,7 @@ import cz.adamec.timotej.snag.network.fe.ports.LocalHostUrlFactory
 import io.ktor.client.HttpClient
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.delete
+import io.ktor.client.request.patch
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.put
@@ -56,6 +57,18 @@ internal class SnagNetworkHttpClientImpl(
         block: HttpRequestBuilder.() -> Unit,
     ): HttpResponse =
         httpClient.put(
+            urlString = localHostUrlFactory.createUrl() + path,
+        ) {
+            contentType(contentType)
+            block()
+        }
+
+    override suspend fun patch(
+        path: String,
+        contentType: ContentType,
+        block: HttpRequestBuilder.() -> Unit,
+    ): HttpResponse =
+        httpClient.patch(
             urlString = localHostUrlFactory.createUrl() + path,
         ) {
             contentType(contentType)


### PR DESCRIPTION
Soft-delete operations (setting deletedAt timestamp) are semantically partial updates, not true deletions. Per RFC 7231, DELETE request body has no defined semantics and may be stripped by infrastructure.

Changed projects, structures, and findings soft-delete endpoints to use PATCH instead of DELETE. Added patch method to SnagNetworkHttpClient interface and implementation for frontend API clients.

Closes #16

https://claude.ai/code/session_01GY2KjXhgBBSnbaRHVW9X4f