### PR TITLE
Use testDispatcher in runTest across 8 test files

### DIFF
--- a/feat/clients/fe/driving/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/clients/fe/driving/impl/internal/clientDetailsEdit/vm/ClientDetailsEditViewModelTest.kt
+++ b/feat/clients/fe/driving/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/clients/fe/driving/impl/internal/clientDetailsEdit/vm/ClientDetailsEditViewModelTest.kt
@@ -52,7 +52,7 @@ class ClientDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `initial state is empty when clientId is null`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel(clientId = null)
 
             assertEquals("", viewModel.state.value.clientName)
@@ -63,7 +63,7 @@ class ClientDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `loading client data updates state when clientId is provided`() =
-        runTest {
+        runTest(testDispatcher) {
             val clientId = Uuid.random()
             val client =
                 FrontendClient(
@@ -91,7 +91,7 @@ class ClientDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onClientNameChange updates state`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel()
 
             viewModel.onClientNameChange("New Name")
@@ -101,7 +101,7 @@ class ClientDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onClientAddressChange updates state`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel()
 
             viewModel.onClientAddressChange("New Address")
@@ -111,7 +111,7 @@ class ClientDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onClientPhoneNumberChange updates state`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel()
 
             viewModel.onClientPhoneNumberChange("+420999888777")
@@ -121,7 +121,7 @@ class ClientDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onClientEmailChange updates state`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel()
 
             viewModel.onClientEmailChange("new@example.com")
@@ -131,7 +131,7 @@ class ClientDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onSaveClient with empty name shows inline error`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel()
 
             viewModel.onSaveClient()
@@ -142,7 +142,7 @@ class ClientDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onSaveClient with invalid email shows inline error`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel()
             viewModel.onClientNameChange("Name")
             viewModel.onClientEmailChange("invalid")
@@ -156,7 +156,7 @@ class ClientDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onSaveClient with invalid phone shows inline error`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel()
             viewModel.onClientNameChange("Name")
             viewModel.onClientPhoneNumberChange("abc")
@@ -170,7 +170,7 @@ class ClientDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onSaveClient with valid optional fields passes validation`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel()
             viewModel.onClientNameChange("Name")
             viewModel.onClientEmailChange("test@example.com")
@@ -187,7 +187,7 @@ class ClientDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `editing field clears its error`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel()
             viewModel.onSaveClient()
             advanceUntilIdle()
@@ -200,7 +200,7 @@ class ClientDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onSaveClient successful sends save event`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel()
             viewModel.onClientNameChange("Name")
 
@@ -216,7 +216,7 @@ class ClientDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onSaveClient failure sends error`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel()
             viewModel.onClientNameChange("Name")
 

--- a/feat/clients/fe/driving/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/clients/fe/driving/impl/internal/clients/vm/ClientsViewModelTest.kt
+++ b/feat/clients/fe/driving/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/clients/fe/driving/impl/internal/clients/vm/ClientsViewModelTest.kt
@@ -40,7 +40,7 @@ class ClientsViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `initial state has empty clients list`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel()
 
             val clients = viewModel.state.value.clients
@@ -49,7 +49,7 @@ class ClientsViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `loads clients from db`() =
-        runTest {
+        runTest(testDispatcher) {
             val client =
                 FrontendClient(
                     client =

--- a/feat/inspections/fe/driving/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/feat/inspections/fe/driving/impl/internal/vm/InspectionEditViewModelTest.kt
+++ b/feat/inspections/fe/driving/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/feat/inspections/fe/driving/impl/internal/vm/InspectionEditViewModelTest.kt
@@ -53,7 +53,7 @@ class InspectionEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `initial state is empty when creating with projectId provided and inspectionId null`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val viewModel = createViewModel(inspectionId = null, projectId = projectId)
 
@@ -67,7 +67,7 @@ class InspectionEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `loading inspection data updates state when editing with inspectionId provided`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val inspectionId = UuidProvider.getUuid()
             val inspection =
@@ -99,7 +99,7 @@ class InspectionEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onParticipantsChange updates state`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val viewModel = createViewModel(projectId = projectId)
 
@@ -110,7 +110,7 @@ class InspectionEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onClimateChange updates state`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val viewModel = createViewModel(projectId = projectId)
 
@@ -121,7 +121,7 @@ class InspectionEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onNoteChange updates state`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val viewModel = createViewModel(projectId = projectId)
 
@@ -132,7 +132,7 @@ class InspectionEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onStartedAtChange updates state`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val viewModel = createViewModel(projectId = projectId)
 
@@ -143,7 +143,7 @@ class InspectionEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onEndedAtChange updates state`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val viewModel = createViewModel(projectId = projectId)
 
@@ -154,7 +154,7 @@ class InspectionEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onSaveInspection successful in create mode sends save event`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val viewModel = createViewModel(projectId = projectId)
             viewModel.onParticipantsChange("John Doe")
@@ -175,7 +175,7 @@ class InspectionEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onSaveInspection successful in edit mode sends save event`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val inspectionId = UuidProvider.getUuid()
             val inspection =
@@ -214,7 +214,7 @@ class InspectionEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onSaveInspection failure sends error`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val viewModel = createViewModel(projectId = projectId)
 

--- a/feat/projects/fe/driving/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetails/vm/ProjectDetailsViewModelTest.kt
+++ b/feat/projects/fe/driving/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetails/vm/ProjectDetailsViewModelTest.kt
@@ -133,7 +133,7 @@ class ProjectDetailsViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `downloading report on success sends report to reportReadyFlow`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = Uuid.random()
             seedProject(projectId)
             val samplePdfBytes = byteArrayOf(0x25, 0x50, 0x44, 0x46)
@@ -153,7 +153,7 @@ class ProjectDetailsViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `downloading report on network failure shows network error`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = Uuid.random()
             seedProject(projectId)
             fakeReportsApi.forcedFailure = OnlineDataResult.Failure.NetworkUnavailable
@@ -170,7 +170,7 @@ class ProjectDetailsViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `downloading report on generic failure shows unknown error`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = Uuid.random()
             seedProject(projectId)
             fakeReportsApi.forcedFailure =
@@ -188,7 +188,7 @@ class ProjectDetailsViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `downloading report calls use case with correct projectId`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = Uuid.random()
             seedProject(projectId)
 
@@ -203,7 +203,7 @@ class ProjectDetailsViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `canDownloadReport is true when loaded and not downloading`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = Uuid.random()
             seedProject(projectId)
 
@@ -216,7 +216,7 @@ class ProjectDetailsViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `canDownloadReport is false when project is not loaded`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = Uuid.random()
 
             val viewModel = createViewModel(projectId)
@@ -226,7 +226,7 @@ class ProjectDetailsViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `canDownloadReport is false while downloading`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = Uuid.random()
             seedProject(projectId)
             val deferred = CompletableDeferred<Unit>()
@@ -253,7 +253,7 @@ class ProjectDetailsViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onStartInspection sets startedAt to current timestamp`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = Uuid.random()
             val inspectionId = Uuid.random()
             seedProject(projectId)
@@ -273,7 +273,7 @@ class ProjectDetailsViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onStartInspection preserves existing fields`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = Uuid.random()
             val inspectionId = Uuid.random()
             seedProject(projectId)
@@ -305,7 +305,7 @@ class ProjectDetailsViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onEndInspection sets endedAt to current timestamp`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = Uuid.random()
             val inspectionId = Uuid.random()
             seedProject(projectId)
@@ -325,7 +325,7 @@ class ProjectDetailsViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onEndInspection preserves existing startedAt`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = Uuid.random()
             val inspectionId = Uuid.random()
             val existingStartedAt = Timestamp(500L)
@@ -350,7 +350,7 @@ class ProjectDetailsViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onStartInspection does nothing for unknown inspection id`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = Uuid.random()
             seedProject(projectId)
 
@@ -365,7 +365,7 @@ class ProjectDetailsViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onEndInspection does nothing for unknown inspection id`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = Uuid.random()
             seedProject(projectId)
 
@@ -380,7 +380,7 @@ class ProjectDetailsViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onStartInspection syncs the inspection`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = Uuid.random()
             val inspectionId = Uuid.random()
             seedProject(projectId)
@@ -401,7 +401,7 @@ class ProjectDetailsViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onEndInspection syncs the inspection`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = Uuid.random()
             val inspectionId = Uuid.random()
             seedProject(projectId)

--- a/feat/projects/fe/driving/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetailsEdit/vm/ProjectDetailsEditViewModelTest.kt
+++ b/feat/projects/fe/driving/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetailsEdit/vm/ProjectDetailsEditViewModelTest.kt
@@ -56,7 +56,7 @@ class ProjectDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `initial state is empty when projectId is null`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel(projectId = null)
 
             assertEquals("", viewModel.state.value.projectName)
@@ -67,7 +67,7 @@ class ProjectDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `loading project data updates state when projectId is provided`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = Uuid.random()
             val project =
                 FrontendProject(
@@ -91,7 +91,7 @@ class ProjectDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onProjectNameChange updates state`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel()
 
             viewModel.onProjectNameChange("New Name")
@@ -101,7 +101,7 @@ class ProjectDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onProjectAddressChange updates state`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel()
 
             viewModel.onProjectAddressChange("New Address")
@@ -111,7 +111,7 @@ class ProjectDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onSaveProject with empty name shows inline error`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel()
             viewModel.onProjectAddressChange("Address")
 
@@ -124,7 +124,7 @@ class ProjectDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onSaveProject with empty address shows inline error`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel()
             viewModel.onProjectNameChange("Name")
 
@@ -137,7 +137,7 @@ class ProjectDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `editing field clears its error`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel()
 
             viewModel.onSaveProject()
@@ -154,7 +154,7 @@ class ProjectDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onSaveProject successful sends save event`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel()
             viewModel.onProjectNameChange("Name")
             viewModel.onProjectAddressChange("Address")
@@ -173,7 +173,7 @@ class ProjectDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onSaveProject failure sends error`() =
-        runTest {
+        runTest(testDispatcher) {
             val viewModel = createViewModel()
             viewModel.onProjectNameChange("Name")
             viewModel.onProjectAddressChange("Address")
@@ -188,7 +188,7 @@ class ProjectDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `clients are loaded into state`() =
-        runTest {
+        runTest(testDispatcher) {
             val clientId = Uuid.random()
             fakeClientsDb.setClient(
                 FrontendClient(
@@ -214,7 +214,7 @@ class ProjectDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `selecting a client updates state`() =
-        runTest {
+        runTest(testDispatcher) {
             val clientId = Uuid.random()
             val viewModel = createViewModel()
 
@@ -226,7 +226,7 @@ class ProjectDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `clearing client selection updates state`() =
-        runTest {
+        runTest(testDispatcher) {
             val clientId = Uuid.random()
             val viewModel = createViewModel()
             viewModel.onClientSelected(clientId, "ACME Corp")
@@ -239,7 +239,7 @@ class ProjectDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `saving project with client includes clientId`() =
-        runTest {
+        runTest(testDispatcher) {
             val clientId = Uuid.random()
             val viewModel = createViewModel()
             viewModel.onProjectNameChange("Name")
@@ -256,7 +256,7 @@ class ProjectDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `editing project with clientId pre-selects client`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = Uuid.random()
             val clientId = Uuid.random()
             fakeClientsDb.setClient(
@@ -294,7 +294,7 @@ class ProjectDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onClientCreated selects newly created client`() =
-        runTest {
+        runTest(testDispatcher) {
             val clientId = Uuid.random()
             fakeClientsDb.setClient(
                 FrontendClient(

--- a/feat/reports/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/reports/be/app/impl/internal/GenerateProjectReportUseCaseImplTest.kt
+++ b/feat/reports/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/reports/be/app/impl/internal/GenerateProjectReportUseCaseImplTest.kt
@@ -39,14 +39,14 @@ class GenerateProjectReportUseCaseImplTest : BackendKoinInitializedTest() {
 
     @Test
     fun `returns null when project does not exist`() =
-        runTest {
+        runTest(testDispatcher) {
             val result = useCase(Uuid.parse("00000000-0000-0000-0000-000000000099"))
             assertNull(result)
         }
 
     @Test
     fun `generates report for existing project`() =
-        runTest {
+        runTest(testDispatcher) {
             projectsDb.saveProject(
                 BackendProject(
                     project =
@@ -71,7 +71,7 @@ class GenerateProjectReportUseCaseImplTest : BackendKoinInitializedTest() {
 
     @Test
     fun `filters soft-deleted structures`() =
-        runTest {
+        runTest(testDispatcher) {
             projectsDb.saveProject(
                 BackendProject(
                     project =

--- a/feat/reports/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/feat/reports/fe/app/impl/internal/DownloadReportUseCaseImplTest.kt
+++ b/feat/reports/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/feat/reports/fe/app/impl/internal/DownloadReportUseCaseImplTest.kt
@@ -30,7 +30,7 @@ class DownloadReportUseCaseImplTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `returns success with bytes on happy path`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = Uuid.random()
             val expectedBytes = byteArrayOf(0x25, 0x50, 0x44, 0x46)
             fakeReportsApi.reportBytes = expectedBytes
@@ -43,7 +43,7 @@ class DownloadReportUseCaseImplTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `propagates API failure`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = Uuid.random()
             fakeReportsApi.forcedFailure = OnlineDataResult.Failure.NetworkUnavailable
 

--- a/feat/structures/fe/driving/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/internal/structureDetailsEdit/vm/StructureDetailsEditViewModelTest.kt
+++ b/feat/structures/fe/driving/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/internal/structureDetailsEdit/vm/StructureDetailsEditViewModelTest.kt
@@ -68,7 +68,7 @@ class StructureDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `initial state is empty when creating with projectId provided and structureId null`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val viewModel = createViewModel(structureId = null, projectId = projectId)
 
@@ -78,7 +78,7 @@ class StructureDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `loading structure data updates state and projectId when editing with structureId provided`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val structureId = UuidProvider.getUuid()
             val structure =
@@ -103,7 +103,7 @@ class StructureDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onStructureNameChange updates state`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val viewModel = createViewModel(projectId = projectId)
 
@@ -114,7 +114,7 @@ class StructureDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onSaveStructure with empty name shows inline error`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val viewModel = createViewModel(projectId = projectId)
 
@@ -126,7 +126,7 @@ class StructureDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `editing name clears its error`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val viewModel = createViewModel(projectId = projectId)
 
@@ -140,7 +140,7 @@ class StructureDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onSaveStructure successful in create mode sends save event`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val viewModel = createViewModel(projectId = projectId)
             viewModel.onStructureNameChange("Name")
@@ -160,7 +160,7 @@ class StructureDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onSaveStructure successful in edit mode sends save event`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val structureId = UuidProvider.getUuid()
             val structure =
@@ -197,7 +197,7 @@ class StructureDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onSaveStructure failure sends error`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val viewModel = createViewModel(projectId = projectId)
             viewModel.onStructureNameChange("Name")
@@ -222,7 +222,7 @@ class StructureDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onImagePicked uploads file and updates floorPlanUrl`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val viewModel = createViewModel(projectId = projectId)
             val bytes = byteArrayOf(1, 2, 3)
@@ -243,7 +243,7 @@ class StructureDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onImagePicked replaces previous pending upload and deletes old one`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val viewModel = createViewModel(projectId = projectId)
 
@@ -264,7 +264,7 @@ class StructureDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onRemoveImage clears floorPlanUrl and deletes pending upload`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val viewModel = createViewModel(projectId = projectId)
 
@@ -282,7 +282,7 @@ class StructureDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onSaveStructure includes floorPlanUrl in saved structure`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val viewModel = createViewModel(projectId = projectId)
             viewModel.onStructureNameChange("Name")
@@ -303,7 +303,7 @@ class StructureDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `onImagePicked failure sends error event`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val viewModel = createViewModel(projectId = projectId)
 
@@ -321,7 +321,7 @@ class StructureDetailsEditViewModelTest : FrontendKoinInitializedTest() {
 
     @Test
     fun `loading existing structure with floorPlanUrl updates state`() =
-        runTest {
+        runTest(testDispatcher) {
             val projectId = UuidProvider.getUuid()
             val structureId = UuidProvider.getUuid()
             val floorPlanUrl = "https://storage.test/existing-plan.png"


### PR DESCRIPTION
## Summary
- Replace `runTest {` with `runTest(testDispatcher) {` in 8 test files (74 occurrences)
- Ensures tests share the DI-wired coroutine dispatcher from `KoinInitializedTest` instead of creating a separate test scope

## Test plan
- [x] All FE test modules pass (`jvmTest` for projects, structures, clients, reports FE, inspections, sync)
- [ ] BE reports test blocked by pre-existing compilation error in `feat/shared/database/be/test` (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)