### PR TITLE
Add SnagConfig for centralized env configuration

### DIFF
--- a/feat/shared/storage/be/build.gradle.kts
+++ b/feat/shared/storage/be/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+    implementation(projects.lib.configuration.be.api)
     implementation(projects.lib.storage.be.api)
     implementation(projects.lib.storage.be.impl)
 }

--- a/feat/shared/storage/be/src/main/kotlin/cz/adamec/timotej/snag/feat/shared/storage/be/di/SharedStorageBeModule.kt
+++ b/feat/shared/storage/be/src/main/kotlin/cz/adamec/timotej/snag/feat/shared/storage/be/di/SharedStorageBeModule.kt
@@ -12,13 +12,13 @@
 
 package cz.adamec.timotej.snag.feat.shared.storage.be.di
 
+import cz.adamec.timotej.snag.configuration.be.SnagConfig
 import cz.adamec.timotej.snag.lib.storage.be.api.FileRouteConfig
 import cz.adamec.timotej.snag.lib.storage.be.impl.di.gcsStorageModule
 import org.koin.dsl.module
 
 val sharedStorageBeModule =
     module {
-        val bucketName = System.getenv("GCS_BUCKET_NAME") ?: "snag-bucket-dev"
-        includes(gcsStorageModule(bucketName = bucketName))
+        includes(gcsStorageModule(bucketName = SnagConfig.gcsBucketName))
         single { FileRouteConfig(routePath = "/files") }
     }

--- a/lib/configuration/be/api/src/main/kotlin/cz/adamec/timotej/snag/configuration/be/SnagConfig.kt
+++ b/lib/configuration/be/api/src/main/kotlin/cz/adamec/timotej/snag/configuration/be/SnagConfig.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.configuration.be
+
+object SnagConfig {
+    val port: Int = System.getenv("PORT")?.toIntOrNull() ?: 8081
+    val gcsBucketName: String = System.getenv("GCS_BUCKET_NAME") ?: "snag-bucket-dev"
+    val corsAllowedHosts: List<String> = parseCorsAllowedHosts()
+    val seedData: Boolean = System.getenv("SEED_DATA")?.toBooleanStrictOrNull() ?: true
+
+    private fun parseCorsAllowedHosts(): List<String> {
+        val envValue = System.getenv("CORS_ALLOWED_HOSTS") ?: return listOf("localhost:8080")
+        return envValue
+            .split(",")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .ifEmpty { listOf("localhost:8080") }
+    }
+}

--- a/lib/configuration/be/impl/src/main/kotlin/cz/adamec/timotej/snag/configuration/be/impl/internal/CorsConfiguration.kt
+++ b/lib/configuration/be/impl/src/main/kotlin/cz/adamec/timotej/snag/configuration/be/impl/internal/CorsConfiguration.kt
@@ -13,6 +13,7 @@
 package cz.adamec.timotej.snag.configuration.be.impl.internal
 
 import cz.adamec.timotej.snag.configuration.be.AppConfiguration
+import cz.adamec.timotej.snag.configuration.be.SnagConfig
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.server.application.Application
@@ -21,14 +22,8 @@ import io.ktor.server.plugins.cors.routing.CORS
 
 internal class CorsConfiguration : AppConfiguration {
     override fun Application.setup() {
-        val allowedHosts = System.getenv("CORS_ALLOWED_HOSTS")
-            ?.split(",")
-            ?.map { it.trim() }
-            ?.filter { it.isNotEmpty() }
-            ?: listOf("localhost:8080")
-
         install(CORS) {
-            for (host in allowedHosts) {
+            for (host in SnagConfig.corsAllowedHosts) {
                 if ("://" in host) {
                     val (scheme, rest) = host.split("://", limit = 2)
                     allowHost(rest, schemes = listOf(scheme))

--- a/server/impl/src/main/kotlin/cz/adamec/timotej/snag/impl/Application.kt
+++ b/server/impl/src/main/kotlin/cz/adamec/timotej/snag/impl/Application.kt
@@ -13,8 +13,8 @@
 package cz.adamec.timotej.snag.impl
 
 import cz.adamec.timotej.snag.configuration.be.AppConfiguration
+import cz.adamec.timotej.snag.configuration.be.SnagConfig
 import cz.adamec.timotej.snag.impl.di.appModule
-import cz.adamec.timotej.snag.server.api.Host
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.engine.embeddedServer
@@ -24,7 +24,7 @@ import org.koin.ktor.plugin.Koin
 import org.koin.logger.slf4jLogger
 
 fun main() {
-    val port = System.getenv("PORT")?.toIntOrNull() ?: Host.Localhost.PORT
+    val port = SnagConfig.port
     embeddedServer(
         factory = Netty,
         port = port,

--- a/server/impl/src/main/kotlin/cz/adamec/timotej/snag/impl/di/AppModule.kt
+++ b/server/impl/src/main/kotlin/cz/adamec/timotej/snag/impl/di/AppModule.kt
@@ -13,6 +13,7 @@
 package cz.adamec.timotej.snag.impl.di
 
 import cz.adamec.timotej.snag.configuration.be.AppConfiguration
+import cz.adamec.timotej.snag.configuration.be.SnagConfig
 import cz.adamec.timotej.snag.di.aggregate.be.backendModulesAggregate
 import cz.adamec.timotej.snag.impl.internal.DevDataSeederConfiguration
 import org.koin.core.module.dsl.singleOf
@@ -22,8 +23,7 @@ import org.koin.dsl.module
 internal val appModule =
     module {
         includes(backendModulesAggregate)
-        val seedData = System.getenv("SEED_DATA")?.toBooleanStrictOrNull() ?: true
-        if (seedData) {
+        if (SnagConfig.seedData) {
             singleOf(::DevDataSeederConfiguration) bind AppConfiguration::class
         }
     }


### PR DESCRIPTION
## Summary
- Add `SnagConfig` object in `lib/configuration/be/api` centralizing all `System.getenv()` reads (`PORT`, `GCS_BUCKET_NAME`, `CORS_ALLOWED_HOSTS`, `SEED_DATA`)
- Replace scattered env var reads across 4 modules with `SnagConfig.*` references
- Add `lib:configuration:be:api` dependency to `feat/shared/storage/be`

## Test plan
- [ ] `./gradlew :server:impl:run` — starts on 8081 with seed data
- [ ] `PORT=9090 SEED_DATA=false ./gradlew :server:impl:run` — starts on 9090, no seed data
- [ ] `./gradlew check` — all tests pass, ktlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)