### PR TITLE
feat: restore cascade-deleted sub-entities on rejected delete

### DIFF
--- a/feat/findings/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/app/api/CascadeRestoreLocalFindingsByStructureIdUseCase.kt
+++ b/feat/findings/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/app/api/CascadeRestoreLocalFindingsByStructureIdUseCase.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.findings.fe.app.api
+
+import kotlin.uuid.Uuid
+
+interface CascadeRestoreLocalFindingsByStructureIdUseCase {
+    suspend operator fun invoke(structureId: Uuid)
+}

--- a/feat/findings/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/app/impl/di/FindingsAppModule.kt
+++ b/feat/findings/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/app/impl/di/FindingsAppModule.kt
@@ -13,6 +13,7 @@
 package cz.adamec.timotej.snag.findings.fe.app.impl.di
 
 import cz.adamec.timotej.snag.findings.fe.app.api.CascadeDeleteLocalFindingsByStructureIdUseCase
+import cz.adamec.timotej.snag.findings.fe.app.api.CascadeRestoreLocalFindingsByStructureIdUseCase
 import cz.adamec.timotej.snag.findings.fe.app.api.DeleteFindingUseCase
 import cz.adamec.timotej.snag.findings.fe.app.api.GetFindingUseCase
 import cz.adamec.timotej.snag.findings.fe.app.api.GetFindingsUseCase
@@ -21,6 +22,7 @@ import cz.adamec.timotej.snag.findings.fe.app.api.SaveFindingCoordinatesUseCase
 import cz.adamec.timotej.snag.findings.fe.app.api.SaveFindingDetailsUseCase
 import cz.adamec.timotej.snag.findings.fe.app.api.SaveNewFindingUseCase
 import cz.adamec.timotej.snag.findings.fe.app.impl.internal.CascadeDeleteLocalFindingsByStructureIdUseCaseImpl
+import cz.adamec.timotej.snag.findings.fe.app.impl.internal.CascadeRestoreLocalFindingsByStructureIdUseCaseImpl
 import cz.adamec.timotej.snag.findings.fe.app.impl.internal.DeleteFindingUseCaseImpl
 import cz.adamec.timotej.snag.findings.fe.app.impl.internal.GetFindingUseCaseImpl
 import cz.adamec.timotej.snag.findings.fe.app.impl.internal.GetFindingsUseCaseImpl
@@ -38,6 +40,7 @@ val findingsAppModule =
     module {
         factoryOf(::DeleteFindingUseCaseImpl) bind DeleteFindingUseCase::class
         factoryOf(::CascadeDeleteLocalFindingsByStructureIdUseCaseImpl) bind CascadeDeleteLocalFindingsByStructureIdUseCase::class
+        factoryOf(::CascadeRestoreLocalFindingsByStructureIdUseCaseImpl) bind CascadeRestoreLocalFindingsByStructureIdUseCase::class
         factoryOf(::GetFindingUseCaseImpl) bind GetFindingUseCase::class
         factoryOf(::GetFindingsUseCaseImpl) bind GetFindingsUseCase::class
         factoryOf(::PullFindingChangesUseCaseImpl) bind PullFindingChangesUseCase::class

--- a/feat/findings/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/app/impl/internal/CascadeRestoreLocalFindingsByStructureIdUseCaseImpl.kt
+++ b/feat/findings/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/app/impl/internal/CascadeRestoreLocalFindingsByStructureIdUseCaseImpl.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.findings.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.findings.fe.app.api.CascadeRestoreLocalFindingsByStructureIdUseCase
+import cz.adamec.timotej.snag.findings.fe.ports.FindingsApi
+import cz.adamec.timotej.snag.findings.fe.ports.FindingsDb
+import cz.adamec.timotej.snag.lib.core.fe.OnlineDataResult
+import kotlin.uuid.Uuid
+
+internal class CascadeRestoreLocalFindingsByStructureIdUseCaseImpl(
+    private val findingsApi: FindingsApi,
+    private val findingsDb: FindingsDb,
+) : CascadeRestoreLocalFindingsByStructureIdUseCase {
+    override suspend operator fun invoke(structureId: Uuid) {
+        when (val result = findingsApi.getFindings(structureId)) {
+            is OnlineDataResult.Success -> findingsDb.saveFindings(result.data)
+            is OnlineDataResult.Failure ->
+                LH.logger.w { "Failed to restore findings for structure $structureId: $result" }
+        }
+    }
+}

--- a/feat/findings/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/findings/fe/app/impl/internal/CascadeRestoreLocalFindingsByStructureIdUseCaseImplTest.kt
+++ b/feat/findings/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/findings/fe/app/impl/internal/CascadeRestoreLocalFindingsByStructureIdUseCaseImplTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.findings.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.feat.findings.business.Finding
+import cz.adamec.timotej.snag.feat.findings.business.FindingType
+import cz.adamec.timotej.snag.feat.findings.fe.model.FrontendFinding
+import cz.adamec.timotej.snag.findings.fe.app.api.CascadeRestoreLocalFindingsByStructureIdUseCase
+import cz.adamec.timotej.snag.findings.fe.driven.test.FakeFindingsApi
+import cz.adamec.timotej.snag.findings.fe.driven.test.FakeFindingsDb
+import cz.adamec.timotej.snag.lib.core.common.Timestamp
+import cz.adamec.timotej.snag.lib.core.fe.OfflineFirstDataResult
+import cz.adamec.timotej.snag.lib.core.fe.OnlineDataResult
+import cz.adamec.timotej.snag.testinfra.fe.FrontendKoinInitializedTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.koin.test.inject
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+class CascadeRestoreLocalFindingsByStructureIdUseCaseImplTest : FrontendKoinInitializedTest() {
+    private val fakeFindingsApi: FakeFindingsApi by inject()
+    private val fakeFindingsDb: FakeFindingsDb by inject()
+
+    private val useCase: CascadeRestoreLocalFindingsByStructureIdUseCase by inject()
+
+    private val structureId = Uuid.parse("00000000-0000-0000-0000-000000000001")
+
+    private fun createFinding(
+        id: Uuid,
+        structureId: Uuid,
+    ) = FrontendFinding(
+        finding =
+            Finding(
+                id = id,
+                structureId = structureId,
+                name = "Finding",
+                description = null,
+                type = FindingType.Classic(),
+                coordinates = emptyList(),
+                updatedAt = Timestamp(1L),
+            ),
+    )
+
+    @Test
+    fun `restores findings from API to local DB`() =
+        runTest(testDispatcher) {
+            val finding1 =
+                createFinding(
+                    id = Uuid.parse("00000000-0000-0000-0001-000000000001"),
+                    structureId = structureId,
+                )
+            val finding2 =
+                createFinding(
+                    id = Uuid.parse("00000000-0000-0000-0001-000000000002"),
+                    structureId = structureId,
+                )
+            fakeFindingsApi.setFindings(listOf(finding1, finding2))
+
+            useCase(structureId)
+
+            val result = fakeFindingsDb.getFindingsFlow(structureId).first()
+            assertIs<OfflineFirstDataResult.Success<List<FrontendFinding>>>(result)
+            assertTrue(result.data.size == 2)
+        }
+
+    @Test
+    fun `does not crash when API fails`() =
+        runTest(testDispatcher) {
+            fakeFindingsApi.forcedFailure =
+                OnlineDataResult.Failure.ProgrammerError(Exception("API error"))
+
+            useCase(structureId)
+
+            val result = fakeFindingsDb.getFindingsFlow(structureId).first()
+            assertIs<OfflineFirstDataResult.Success<List<FrontendFinding>>>(result)
+            assertTrue(result.data.isEmpty())
+        }
+}

--- a/feat/inspections/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/feat/inspections/fe/app/api/CascadeRestoreLocalInspectionsByProjectIdUseCase.kt
+++ b/feat/inspections/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/feat/inspections/fe/app/api/CascadeRestoreLocalInspectionsByProjectIdUseCase.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.feat.inspections.fe.app.api
+
+import kotlin.uuid.Uuid
+
+interface CascadeRestoreLocalInspectionsByProjectIdUseCase {
+    suspend operator fun invoke(projectId: Uuid)
+}

--- a/feat/inspections/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/feat/inspections/fe/app/impl/di/InspectionsAppModule.kt
+++ b/feat/inspections/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/feat/inspections/fe/app/impl/di/InspectionsAppModule.kt
@@ -13,12 +13,14 @@
 package cz.adamec.timotej.snag.feat.inspections.fe.app.impl.di
 
 import cz.adamec.timotej.snag.feat.inspections.fe.app.api.CascadeDeleteLocalInspectionsByProjectIdUseCase
+import cz.adamec.timotej.snag.feat.inspections.fe.app.api.CascadeRestoreLocalInspectionsByProjectIdUseCase
 import cz.adamec.timotej.snag.feat.inspections.fe.app.api.DeleteInspectionUseCase
 import cz.adamec.timotej.snag.feat.inspections.fe.app.api.GetInspectionUseCase
 import cz.adamec.timotej.snag.feat.inspections.fe.app.api.GetInspectionsUseCase
 import cz.adamec.timotej.snag.feat.inspections.fe.app.api.PullInspectionChangesUseCase
 import cz.adamec.timotej.snag.feat.inspections.fe.app.api.SaveInspectionUseCase
 import cz.adamec.timotej.snag.feat.inspections.fe.app.impl.internal.CascadeDeleteLocalInspectionsByProjectIdUseCaseImpl
+import cz.adamec.timotej.snag.feat.inspections.fe.app.impl.internal.CascadeRestoreLocalInspectionsByProjectIdUseCaseImpl
 import cz.adamec.timotej.snag.feat.inspections.fe.app.impl.internal.DeleteInspectionUseCaseImpl
 import cz.adamec.timotej.snag.feat.inspections.fe.app.impl.internal.GetInspectionUseCaseImpl
 import cz.adamec.timotej.snag.feat.inspections.fe.app.impl.internal.GetInspectionsUseCaseImpl
@@ -37,6 +39,7 @@ val inspectionsAppModule =
         factoryOf(::GetInspectionsUseCaseImpl) bind GetInspectionsUseCase::class
         factoryOf(::SaveInspectionUseCaseImpl) bind SaveInspectionUseCase::class
         factoryOf(::CascadeDeleteLocalInspectionsByProjectIdUseCaseImpl) bind CascadeDeleteLocalInspectionsByProjectIdUseCase::class
+        factoryOf(::CascadeRestoreLocalInspectionsByProjectIdUseCaseImpl) bind CascadeRestoreLocalInspectionsByProjectIdUseCase::class
         factoryOf(::PullInspectionChangesUseCaseImpl) bind PullInspectionChangesUseCase::class
         factoryOf(::InspectionSyncHandler) bind SyncOperationHandler::class
     }

--- a/feat/inspections/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/feat/inspections/fe/app/impl/internal/CascadeRestoreLocalInspectionsByProjectIdUseCaseImpl.kt
+++ b/feat/inspections/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/feat/inspections/fe/app/impl/internal/CascadeRestoreLocalInspectionsByProjectIdUseCaseImpl.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.feat.inspections.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.feat.inspections.fe.app.api.CascadeRestoreLocalInspectionsByProjectIdUseCase
+import cz.adamec.timotej.snag.feat.inspections.fe.ports.InspectionsApi
+import cz.adamec.timotej.snag.feat.inspections.fe.ports.InspectionsDb
+import cz.adamec.timotej.snag.lib.core.fe.OnlineDataResult
+import kotlin.uuid.Uuid
+
+internal class CascadeRestoreLocalInspectionsByProjectIdUseCaseImpl(
+    private val inspectionsApi: InspectionsApi,
+    private val inspectionsDb: InspectionsDb,
+) : CascadeRestoreLocalInspectionsByProjectIdUseCase {
+    override suspend operator fun invoke(projectId: Uuid) {
+        when (val result = inspectionsApi.getInspections(projectId)) {
+            is OnlineDataResult.Success ->
+                result.data.forEach { inspectionsDb.saveInspection(it) }
+            is OnlineDataResult.Failure ->
+                LH.logger.w { "Failed to restore inspections for project $projectId: $result" }
+        }
+    }
+}

--- a/feat/inspections/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/feat/inspections/fe/app/impl/internal/CascadeRestoreLocalInspectionsByProjectIdUseCaseImplTest.kt
+++ b/feat/inspections/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/feat/inspections/fe/app/impl/internal/CascadeRestoreLocalInspectionsByProjectIdUseCaseImplTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.feat.inspections.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.feat.inspections.business.Inspection
+import cz.adamec.timotej.snag.feat.inspections.fe.app.api.CascadeRestoreLocalInspectionsByProjectIdUseCase
+import cz.adamec.timotej.snag.feat.inspections.fe.driven.test.FakeInspectionsApi
+import cz.adamec.timotej.snag.feat.inspections.fe.driven.test.FakeInspectionsDb
+import cz.adamec.timotej.snag.feat.inspections.fe.model.FrontendInspection
+import cz.adamec.timotej.snag.lib.core.common.Timestamp
+import cz.adamec.timotej.snag.lib.core.fe.OfflineFirstDataResult
+import cz.adamec.timotej.snag.lib.core.fe.OnlineDataResult
+import cz.adamec.timotej.snag.testinfra.fe.FrontendKoinInitializedTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.koin.test.inject
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+class CascadeRestoreLocalInspectionsByProjectIdUseCaseImplTest : FrontendKoinInitializedTest() {
+    private val fakeInspectionsApi: FakeInspectionsApi by inject()
+    private val fakeInspectionsDb: FakeInspectionsDb by inject()
+
+    private val useCase: CascadeRestoreLocalInspectionsByProjectIdUseCase by inject()
+
+    private val projectId = Uuid.parse("00000000-0000-0000-0000-000000000001")
+
+    private fun createInspection(
+        id: Uuid,
+        projectId: Uuid,
+    ) = FrontendInspection(
+        inspection =
+            Inspection(
+                id = id,
+                projectId = projectId,
+                startedAt = null,
+                endedAt = null,
+                participants = null,
+                climate = null,
+                note = null,
+                updatedAt = Timestamp(1L),
+            ),
+    )
+
+    @Test
+    fun `restores inspections from API to local DB`() =
+        runTest(testDispatcher) {
+            val inspection1 =
+                createInspection(
+                    id = Uuid.parse("00000000-0000-0000-0001-000000000001"),
+                    projectId = projectId,
+                )
+            val inspection2 =
+                createInspection(
+                    id = Uuid.parse("00000000-0000-0000-0001-000000000002"),
+                    projectId = projectId,
+                )
+            fakeInspectionsApi.setInspections(listOf(inspection1, inspection2))
+
+            useCase(projectId)
+
+            val result = fakeInspectionsDb.getInspectionsFlow(projectId).first()
+            assertIs<OfflineFirstDataResult.Success<List<FrontendInspection>>>(result)
+            assertTrue(result.data.size == 2)
+        }
+
+    @Test
+    fun `does not crash when API fails`() =
+        runTest(testDispatcher) {
+            fakeInspectionsApi.forcedFailure =
+                OnlineDataResult.Failure.ProgrammerError(Exception("API error"))
+
+            useCase(projectId)
+
+            val result = fakeInspectionsDb.getInspectionsFlow(projectId).first()
+            assertIs<OfflineFirstDataResult.Success<List<FrontendInspection>>>(result)
+            assertTrue(result.data.isEmpty())
+        }
+}

--- a/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/sync/ProjectSyncHandler.kt
+++ b/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/sync/ProjectSyncHandler.kt
@@ -12,6 +12,7 @@
 
 package cz.adamec.timotej.snag.projects.fe.app.impl.internal.sync
 
+import cz.adamec.timotej.snag.feat.inspections.fe.app.api.CascadeRestoreLocalInspectionsByProjectIdUseCase
 import cz.adamec.timotej.snag.lib.core.common.Timestamp
 import cz.adamec.timotej.snag.lib.core.common.TimestampProvider
 import cz.adamec.timotej.snag.lib.core.fe.OfflineFirstDataResult
@@ -21,12 +22,17 @@ import cz.adamec.timotej.snag.projects.fe.app.impl.internal.LH
 import cz.adamec.timotej.snag.projects.fe.model.FrontendProject
 import cz.adamec.timotej.snag.projects.fe.ports.ProjectsApi
 import cz.adamec.timotej.snag.projects.fe.ports.ProjectsDb
+import cz.adamec.timotej.snag.structures.fe.app.api.CascadeRestoreLocalStructuresByProjectIdUseCase
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 import kotlin.uuid.Uuid
 
 internal class ProjectSyncHandler(
     private val projectsApi: ProjectsApi,
     private val projectsDb: ProjectsDb,
+    private val cascadeRestoreLocalStructuresByProjectIdUseCase: CascadeRestoreLocalStructuresByProjectIdUseCase,
+    private val cascadeRestoreLocalInspectionsByProjectIdUseCase: CascadeRestoreLocalInspectionsByProjectIdUseCase,
     timestampProvider: TimestampProvider,
 ) : DbApiSyncHandler<FrontendProject>(LH.logger, timestampProvider) {
     override val entityTypeId: String = PROJECT_SYNC_ENTITY_TYPE
@@ -42,4 +48,11 @@ internal class ProjectSyncHandler(
     ): OnlineDataResult<FrontendProject?> = projectsApi.deleteProject(entityId, deletedAt)
 
     override suspend fun saveEntityToDb(entity: FrontendProject): OfflineFirstDataResult<Unit> = projectsDb.saveProject(entity)
+
+    override suspend fun onDeleteRejected(entityId: Uuid) {
+        coroutineScope {
+            launch { cascadeRestoreLocalStructuresByProjectIdUseCase(entityId) }
+            launch { cascadeRestoreLocalInspectionsByProjectIdUseCase(entityId) }
+        }
+    }
 }

--- a/feat/structures/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/app/api/CascadeRestoreLocalStructuresByProjectIdUseCase.kt
+++ b/feat/structures/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/app/api/CascadeRestoreLocalStructuresByProjectIdUseCase.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.structures.fe.app.api
+
+import kotlin.uuid.Uuid
+
+interface CascadeRestoreLocalStructuresByProjectIdUseCase {
+    suspend operator fun invoke(projectId: Uuid)
+}

--- a/feat/structures/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/app/impl/di/StructuresAppModule.kt
+++ b/feat/structures/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/app/impl/di/StructuresAppModule.kt
@@ -15,6 +15,7 @@ package cz.adamec.timotej.snag.structures.fe.app.impl.di
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.handler.SyncOperationHandler
 import cz.adamec.timotej.snag.structures.fe.app.api.CanModifyFloorPlanImageUseCase
 import cz.adamec.timotej.snag.structures.fe.app.api.CascadeDeleteLocalStructuresByProjectIdUseCase
+import cz.adamec.timotej.snag.structures.fe.app.api.CascadeRestoreLocalStructuresByProjectIdUseCase
 import cz.adamec.timotej.snag.structures.fe.app.api.DeleteFloorPlanImageUseCase
 import cz.adamec.timotej.snag.structures.fe.app.api.DeleteStructureUseCase
 import cz.adamec.timotej.snag.structures.fe.app.api.GetStructureUseCase
@@ -24,6 +25,7 @@ import cz.adamec.timotej.snag.structures.fe.app.api.SaveStructureUseCase
 import cz.adamec.timotej.snag.structures.fe.app.api.UploadFloorPlanImageUseCase
 import cz.adamec.timotej.snag.structures.fe.app.impl.internal.CanModifyFloorPlanImageUseCaseImpl
 import cz.adamec.timotej.snag.structures.fe.app.impl.internal.CascadeDeleteLocalStructuresByProjectIdUseCaseImpl
+import cz.adamec.timotej.snag.structures.fe.app.impl.internal.CascadeRestoreLocalStructuresByProjectIdUseCaseImpl
 import cz.adamec.timotej.snag.structures.fe.app.impl.internal.DeleteFloorPlanImageUseCaseImpl
 import cz.adamec.timotej.snag.structures.fe.app.impl.internal.DeleteStructureUseCaseImpl
 import cz.adamec.timotej.snag.structures.fe.app.impl.internal.GetStructureUseCaseImpl
@@ -43,6 +45,7 @@ val structuresAppModule =
         factoryOf(::GetStructuresUseCaseImpl) bind GetStructuresUseCase::class
         factoryOf(::SaveStructureUseCaseImpl) bind SaveStructureUseCase::class
         factoryOf(::CascadeDeleteLocalStructuresByProjectIdUseCaseImpl) bind CascadeDeleteLocalStructuresByProjectIdUseCase::class
+        factoryOf(::CascadeRestoreLocalStructuresByProjectIdUseCaseImpl) bind CascadeRestoreLocalStructuresByProjectIdUseCase::class
         factoryOf(::PullStructureChangesUseCaseImpl) bind PullStructureChangesUseCase::class
         factoryOf(::UploadFloorPlanImageUseCaseImpl) bind UploadFloorPlanImageUseCase::class
         factoryOf(::DeleteFloorPlanImageUseCaseImpl) bind DeleteFloorPlanImageUseCase::class

--- a/feat/structures/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/app/impl/internal/CascadeRestoreLocalStructuresByProjectIdUseCaseImpl.kt
+++ b/feat/structures/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/app/impl/internal/CascadeRestoreLocalStructuresByProjectIdUseCaseImpl.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.structures.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.findings.fe.app.api.CascadeRestoreLocalFindingsByStructureIdUseCase
+import cz.adamec.timotej.snag.lib.core.fe.OnlineDataResult
+import cz.adamec.timotej.snag.structures.fe.app.api.CascadeRestoreLocalStructuresByProjectIdUseCase
+import cz.adamec.timotej.snag.structures.fe.ports.StructuresApi
+import cz.adamec.timotej.snag.structures.fe.ports.StructuresDb
+import kotlin.uuid.Uuid
+
+internal class CascadeRestoreLocalStructuresByProjectIdUseCaseImpl(
+    private val structuresApi: StructuresApi,
+    private val structuresDb: StructuresDb,
+    private val cascadeRestoreLocalFindingsByStructureIdUseCase: CascadeRestoreLocalFindingsByStructureIdUseCase,
+) : CascadeRestoreLocalStructuresByProjectIdUseCase {
+    override suspend operator fun invoke(projectId: Uuid) {
+        when (val result = structuresApi.getStructures(projectId)) {
+            is OnlineDataResult.Success -> {
+                structuresDb.saveStructures(result.data)
+                result.data.forEach {
+                    cascadeRestoreLocalFindingsByStructureIdUseCase(it.structure.id)
+                }
+            }
+            is OnlineDataResult.Failure ->
+                LH.logger.w { "Failed to restore structures for project $projectId: $result" }
+        }
+    }
+}

--- a/feat/structures/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/app/impl/internal/sync/StructureSyncHandler.kt
+++ b/feat/structures/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/app/impl/internal/sync/StructureSyncHandler.kt
@@ -13,6 +13,7 @@
 package cz.adamec.timotej.snag.structures.fe.app.impl.internal.sync
 
 import cz.adamec.timotej.snag.feat.structures.fe.model.FrontendStructure
+import cz.adamec.timotej.snag.findings.fe.app.api.CascadeRestoreLocalFindingsByStructureIdUseCase
 import cz.adamec.timotej.snag.lib.core.common.Timestamp
 import cz.adamec.timotej.snag.lib.core.common.TimestampProvider
 import cz.adamec.timotej.snag.lib.core.fe.OfflineFirstDataResult
@@ -27,6 +28,7 @@ import kotlin.uuid.Uuid
 internal class StructureSyncHandler(
     private val structuresApi: StructuresApi,
     private val structuresDb: StructuresDb,
+    private val cascadeRestoreLocalFindingsByStructureIdUseCase: CascadeRestoreLocalFindingsByStructureIdUseCase,
     timestampProvider: TimestampProvider,
 ) : DbApiSyncHandler<FrontendStructure>(LH.logger, timestampProvider) {
     override val entityTypeId: String = STRUCTURE_SYNC_ENTITY_TYPE
@@ -43,4 +45,8 @@ internal class StructureSyncHandler(
     ): OnlineDataResult<FrontendStructure?> = structuresApi.deleteStructure(entityId, deletedAt)
 
     override suspend fun saveEntityToDb(entity: FrontendStructure): OfflineFirstDataResult<Unit> = structuresDb.saveStructure(entity)
+
+    override suspend fun onDeleteRejected(entityId: Uuid) {
+        cascadeRestoreLocalFindingsByStructureIdUseCase(entityId)
+    }
 }

--- a/feat/structures/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/structures/fe/app/impl/internal/CascadeRestoreLocalStructuresByProjectIdUseCaseImplTest.kt
+++ b/feat/structures/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/structures/fe/app/impl/internal/CascadeRestoreLocalStructuresByProjectIdUseCaseImplTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.structures.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.feat.findings.business.Finding
+import cz.adamec.timotej.snag.feat.findings.business.FindingType
+import cz.adamec.timotej.snag.feat.findings.fe.model.FrontendFinding
+import cz.adamec.timotej.snag.feat.structures.business.Structure
+import cz.adamec.timotej.snag.feat.structures.fe.model.FrontendStructure
+import cz.adamec.timotej.snag.findings.fe.driven.test.FakeFindingsApi
+import cz.adamec.timotej.snag.findings.fe.driven.test.FakeFindingsDb
+import cz.adamec.timotej.snag.lib.core.common.Timestamp
+import cz.adamec.timotej.snag.lib.core.fe.OfflineFirstDataResult
+import cz.adamec.timotej.snag.lib.core.fe.OnlineDataResult
+import cz.adamec.timotej.snag.structures.fe.app.api.CascadeRestoreLocalStructuresByProjectIdUseCase
+import cz.adamec.timotej.snag.structures.fe.driven.test.FakeStructuresApi
+import cz.adamec.timotej.snag.structures.fe.driven.test.FakeStructuresDb
+import cz.adamec.timotej.snag.testinfra.fe.FrontendKoinInitializedTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.koin.test.inject
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+class CascadeRestoreLocalStructuresByProjectIdUseCaseImplTest : FrontendKoinInitializedTest() {
+    private val fakeStructuresApi: FakeStructuresApi by inject()
+    private val fakeStructuresDb: FakeStructuresDb by inject()
+    private val fakeFindingsApi: FakeFindingsApi by inject()
+    private val fakeFindingsDb: FakeFindingsDb by inject()
+
+    private val useCase: CascadeRestoreLocalStructuresByProjectIdUseCase by inject()
+
+    private val projectId = Uuid.parse("00000000-0000-0000-0000-000000000001")
+    private val structureId1 = Uuid.parse("00000000-0000-0000-0001-000000000001")
+    private val structureId2 = Uuid.parse("00000000-0000-0000-0001-000000000002")
+
+    private fun createStructure(
+        id: Uuid,
+        projectId: Uuid,
+    ) = FrontendStructure(
+        structure =
+            Structure(
+                id = id,
+                projectId = projectId,
+                name = "Structure",
+                floorPlanUrl = null,
+                updatedAt = Timestamp(1L),
+            ),
+    )
+
+    private fun createFinding(
+        id: Uuid,
+        structureId: Uuid,
+    ) = FrontendFinding(
+        finding =
+            Finding(
+                id = id,
+                structureId = structureId,
+                name = "Finding",
+                description = null,
+                type = FindingType.Classic(),
+                coordinates = emptyList(),
+                updatedAt = Timestamp(1L),
+            ),
+    )
+
+    @Test
+    fun `restores structures from API to local DB`() =
+        runTest(testDispatcher) {
+            val structure1 = createStructure(id = structureId1, projectId = projectId)
+            val structure2 = createStructure(id = structureId2, projectId = projectId)
+            fakeStructuresApi.setStructures(listOf(structure1, structure2))
+
+            useCase(projectId)
+
+            val result = fakeStructuresDb.getStructuresFlow(projectId).first()
+            assertIs<OfflineFirstDataResult.Success<List<FrontendStructure>>>(result)
+            assertTrue(result.data.size == 2)
+        }
+
+    @Test
+    fun `restores findings for each restored structure`() =
+        runTest(testDispatcher) {
+            val structure1 = createStructure(id = structureId1, projectId = projectId)
+            fakeStructuresApi.setStructures(listOf(structure1))
+
+            val finding1 =
+                createFinding(
+                    id = Uuid.parse("00000000-0000-0000-0002-000000000001"),
+                    structureId = structureId1,
+                )
+            val finding2 =
+                createFinding(
+                    id = Uuid.parse("00000000-0000-0000-0002-000000000002"),
+                    structureId = structureId1,
+                )
+            fakeFindingsApi.setFindings(listOf(finding1, finding2))
+
+            useCase(projectId)
+
+            val findingsResult = fakeFindingsDb.getFindingsFlow(structureId1).first()
+            assertIs<OfflineFirstDataResult.Success<List<FrontendFinding>>>(findingsResult)
+            assertTrue(findingsResult.data.size == 2)
+        }
+
+    @Test
+    fun `does not crash when API fails`() =
+        runTest(testDispatcher) {
+            fakeStructuresApi.forcedFailure =
+                OnlineDataResult.Failure.ProgrammerError(Exception("API error"))
+
+            useCase(projectId)
+
+            val result = fakeStructuresDb.getStructuresFlow(projectId).first()
+            assertIs<OfflineFirstDataResult.Success<List<FrontendStructure>>>(result)
+            assertTrue(result.data.isEmpty())
+        }
+}

--- a/lib/sync/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/sync/fe/app/api/handler/DbApiSyncHandler.kt
+++ b/lib/sync/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/sync/fe/app/api/handler/DbApiSyncHandler.kt
@@ -42,6 +42,8 @@ abstract class DbApiSyncHandler<T>(
 
     protected abstract suspend fun saveEntityToDb(entity: T): OfflineFirstDataResult<Unit>
 
+    protected open suspend fun onDeleteRejected(entityId: Uuid) {}
+
     override suspend fun execute(
         entityId: Uuid,
         operationType: SyncOperationType,
@@ -94,6 +96,7 @@ abstract class DbApiSyncHandler<T>(
                 result.data?.let { updatedEntity ->
                     logger.d { "Delete of $entityName $entityId rejected by API. Saving fresher $updatedEntity to DB." }
                     saveEntityToDb(updatedEntity)
+                    onDeleteRejected(entityId)
                 } ?: logger.d { "Deleted $entityName $entityId from API." }
                 SyncOperationResult.Success
             }

--- a/lib/sync/fe/app/api/src/commonTest/kotlin/cz/adamec/timotej/snag/lib/sync/fe/app/api/handler/DbApiSyncHandlerTest.kt
+++ b/lib/sync/fe/app/api/src/commonTest/kotlin/cz/adamec/timotej/snag/lib/sync/fe/app/api/handler/DbApiSyncHandlerTest.kt
@@ -79,6 +79,12 @@ class DbApiSyncHandlerTest {
             return OfflineFirstDataResult.Success(Unit)
         }
 
+        var lastDeleteRejectedEntityId: Uuid? = null
+
+        override suspend fun onDeleteRejected(entityId: Uuid) {
+            lastDeleteRejectedEntityId = entityId
+        }
+
         fun getDbEntity(id: Uuid): TestEntity? = db[id]
     }
 
@@ -185,6 +191,30 @@ class DbApiSyncHandlerTest {
 
             assertEquals(SyncOperationResult.Success, result)
             assertNull(handler.getDbEntity(entityId))
+        }
+
+    @Test
+    fun `executeDelete calls onDeleteRejected when api returns entity`() =
+        runTest(testDispatcher) {
+            val entity = createEntity(name = "Restored by API")
+            val handler =
+                TestDbApiSyncHandler(
+                    apiDeleteResponse = { OnlineDataResult.Success(entity) },
+                )
+
+            handler.execute(entity.id, SyncOperationType.DELETE)
+
+            assertEquals(entity.id, handler.lastDeleteRejectedEntityId)
+        }
+
+    @Test
+    fun `executeDelete does not call onDeleteRejected when api returns null`() =
+        runTest(testDispatcher) {
+            val handler = TestDbApiSyncHandler()
+
+            handler.execute(UuidProvider.getUuid(), SyncOperationType.DELETE)
+
+            assertNull(handler.lastDeleteRejectedEntityId)
         }
 
     @Test


### PR DESCRIPTION
## Summary
- Adds `onDeleteRejected` hook to `DbApiSyncHandler`, called after the API rejects a delete and the parent entity is restored to the local DB
- Overrides the hook in `StructureSyncHandler` to re-fetch and restore cascade-deleted findings from the API
- Overrides the hook in `ProjectSyncHandler` to re-fetch and restore cascade-deleted structures (+ their findings) and inspections from the API

## Test plan
- [x] `DbApiSyncHandlerTest` — verifies `onDeleteRejected` is called when delete is rejected, not called when delete succeeds
- [x] `CascadeRestoreLocalFindingsByStructureIdUseCaseImplTest` — API success → findings saved; API failure → no crash
- [x] `CascadeRestoreLocalStructuresByProjectIdUseCaseImplTest` — API success → structures saved + findings restored per structure; API failure → no crash
- [x] `CascadeRestoreLocalInspectionsByProjectIdUseCaseImplTest` — API success → inspections saved; API failure → no crash
- [x] `./gradlew assemble` passes
- [x] `./gradlew ktlintCheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)