### PR TITLE
docs: generalize api/impl module split documentation

### DIFF
--- a/.claude/skills/gradle-plugins/SKILL.md
+++ b/.claude/skills/gradle-plugins/SKILL.md
@@ -37,6 +37,7 @@ feat/<feature>/
     │   ├── impl/            → snagBackendModule
     │   └── test/            → snagBackendModule
     ├── driving/
+    │   ├── api/             → snagBackendModule
     │   ├── contract/        → snagContractDrivingBackendMultiplatformModule
     │   └── impl/            → snagImplDrivingBackendModule
     └── driven/

--- a/.claude/skills/project-structure/SKILL.md
+++ b/.claude/skills/project-structure/SKILL.md
@@ -30,9 +30,10 @@ Each feature follows hexagonal architecture with these layers:
 
 ### Module splits
 
-- `api/` or `contract/` — Public interfaces (typical for `app/` and `driving/`)
+- `api/` or `contract/` — Public interfaces or cross-feature-accessible code. Can appear in any layer.
+  `contract/` is a special variant for shared FE/BE DTOs (driving layer).
 - `impl/` — Production implementations
-- `test/` — Fake/in-memory implementations for unit tests
+- `test/` — Fake/in-memory implementations for unit tests (typical for `driven/` layer)
 
 ### Shared modules (`feat/shared/`)
 

--- a/docs/gradle_plugins.md
+++ b/docs/gradle_plugins.md
@@ -165,6 +165,7 @@ feat/<feature>/
     │   ├── api/             → snagBackendModule
     │   └── impl/            → snagBackendModule
     ├── driving/
+    │   ├── api/             → snagBackendModule
     │   ├── contract/        → snagContractDrivingBackendMultiplatformModule
     │   └── impl/            → snagImplDrivingBackendModule
     └── driven/

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -36,19 +36,13 @@ integrates with technologies. This code depends on the `app` module for applicat
 
 #### Feature module splits
 Each feature module/directory can be split into submodules if there is a need for it:
-- `api`/`contract`
-  - `contract` is a special api code that is used as a contract between the frontend and backend but
-    is in the `driving` adapter layer, not in the core `business` layer.
-- `impl` - contains production implementations for use in production.
-  - Depends on `api`/`contract`.
-- `test` - contains in-memory and other non-production unit-test-friendly implementations for use
-  instead of `impl`.
-    - Depends on `api`/`contract`.
-
-The `api` and `impl` split is typical for frontend `driving` code and for `app` layer.
-The `test` and `impl` split is typical for driven code so that tests in `driving` and `app` layers
-can run with non-production unit-test-friendly adapter `ports`.
-The `contract` and `impl` split is typical for backend driving code.
+- `api` — Public interfaces or cross-feature-accessible code. Can appear in any layer.
+  - `contract` is a special variant of `api` used as a shared FE/BE contract in the `driving`
+    adapter layer (not in the core `business` layer).
+- `impl` — Production implementations. Depends on `api`/`contract`.
+- `test` — In-memory and other non-production unit-test-friendly implementations for use instead
+  of `impl`. Depends on `api`/`contract`. Typical for the `driven` layer so that tests in
+  `driving` and `app` layers can run with non-production unit-test-friendly adapter `ports`.
 
 ### Shared modules (`feat/shared/`)
 


### PR DESCRIPTION
## Summary
- Generalize `api/impl` split as applicable to any layer (not just `app` and `driving`)
- Keep `test` split documented as typical for the `driven` layer
- Add `driving/api/ → snagBackendModule` to BE module path → plugin mappings

## Test plan
- [ ] Docs-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)