### PR TITLE
feat: hide structure toolbar when finding is selected

### DIFF
--- a/feat/structures/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/internal/floorPlan/ui/StructureFloorPlanContent.kt
+++ b/feat/structures/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/internal/floorPlan/ui/StructureFloorPlanContent.kt
@@ -12,6 +12,11 @@
 
 package cz.adamec.timotej.snag.structures.fe.driving.impl.internal.floorPlan.ui
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateStartPadding
@@ -217,34 +222,40 @@ private fun LoadedStructureDetailsContent(
                     },
                 )
             }
-            HorizontalFloatingToolbar(
-                modifier =
-                    Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(bottom = toolbarBottomPadding)
-                        .onGloballyPositioned {
-                            toolbarTopPx = it.positionInParent().y.toInt()
-                        },
-                expanded = true,
+            AnimatedVisibility(
+                modifier = Modifier.align(Alignment.BottomCenter),
+                visible = state.selectedFindingId == null,
+                enter = fadeIn() + slideInVertically { it },
+                exit = fadeOut() + slideOutVertically { it },
             ) {
-                IconButton(
-                    onClick = onEditClick,
+                HorizontalFloatingToolbar(
+                    modifier =
+                        Modifier
+                            .padding(bottom = toolbarBottomPadding)
+                            .onGloballyPositioned {
+                                toolbarTopPx = it.positionInParent().y.toInt()
+                            },
+                    expanded = true,
                 ) {
-                    Icon(
-                        painter = painterResource(DesignRes.drawable.ic_edit),
-                        contentDescription = stringResource(DesignRes.string.edit),
-                    )
-                }
-                IconButton(
-                    enabled = state.canInvokeDeletion,
-                    onClick = {
-                        isShowingDeleteConfirmation = true
-                    },
-                ) {
-                    Icon(
-                        painter = painterResource(DesignRes.drawable.ic_delete),
-                        contentDescription = stringResource(DesignRes.string.delete),
-                    )
+                    IconButton(
+                        onClick = onEditClick,
+                    ) {
+                        Icon(
+                            painter = painterResource(DesignRes.drawable.ic_edit),
+                            contentDescription = stringResource(DesignRes.string.edit),
+                        )
+                    }
+                    IconButton(
+                        enabled = state.canInvokeDeletion,
+                        onClick = {
+                            isShowingDeleteConfirmation = true
+                        },
+                    ) {
+                        Icon(
+                            painter = painterResource(DesignRes.drawable.ic_delete),
+                            contentDescription = stringResource(DesignRes.string.delete),
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Problem Statement
The structure actions toolbar (edit/delete) stays visible when a finding is selected on the floor plan, adding visual clutter and risk of accidental actions.

## Solution
Wrap `HorizontalFloatingToolbar` with `AnimatedVisibility` that hides the toolbar when `selectedFindingId` is non-null. Uses fade + slide-down animations for smooth transitions.

## Test Coverage
- Build verified: `:feat:structures:fe:driving:impl:assemble` passes
- Manual: open floor plan → toolbar visible → tap finding pin → toolbar animates out → deselect → toolbar animates back in

## References
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)