### PR TITLE
feat: expressive finding detail

### DIFF
--- a/feat/findings/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driving/impl/internal/findingDetail/ui/FindingDetailContent.kt
+++ b/feat/findings/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driving/impl/internal/findingDetail/ui/FindingDetailContent.kt
@@ -12,6 +12,7 @@
 
 package cz.adamec.timotej.snag.findings.fe.driving.impl.internal.findingDetail.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,10 +22,13 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ContainedLoadingIndicator
+import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.FloatingToolbarDefaults
 import androidx.compose.material3.HorizontalFloatingToolbar
 import androidx.compose.material3.Icon
@@ -41,6 +45,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.LayoutDirection
@@ -174,28 +179,40 @@ internal fun FindingDetailContent(
                             ).consumeWindowInsets(paddingValues)
                             .padding(16.dp),
                 ) {
-                    Column {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                    ) {
                         val type = finding.finding.type
                         val visuals = type.visuals()
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
                         ) {
-                            Icon(
-                                painter = painterResource(visuals.icon),
-                                contentDescription = null,
-                                modifier = Modifier.size(20.dp),
-                                tint = visuals.pinColor,
-                            )
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .size(40.dp)
+                                        .clip(MaterialTheme.shapes.medium)
+                                        .background(
+                                            visuals.pinColor.copy(alpha = 0.12f),
+                                        ),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Icon(
+                                    painter = painterResource(visuals.icon),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(24.dp),
+                                    tint = visuals.pinColor,
+                                )
+                            }
                             Text(
                                 text = stringResource(visuals.label),
-                                style = MaterialTheme.typography.labelMedium,
+                                style = MaterialTheme.typography.titleMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                         }
                         if (type is FindingType.Classic) {
                             Row(
-                                modifier = Modifier.padding(top = 8.dp),
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                             ) {
                                 ImportanceLabel(
@@ -207,22 +224,32 @@ internal fun FindingDetailContent(
                             }
                         }
                         finding.finding.description?.let { description ->
-                            Text(
-                                modifier = Modifier.padding(top = 8.dp),
-                                text = description,
-                                style = MaterialTheme.typography.bodyMedium,
-                            )
+                            ElevatedCard(
+                                modifier = Modifier.fillMaxWidth(),
+                                shape = MaterialTheme.shapes.large,
+                                colors =
+                                    CardDefaults.elevatedCardColors(
+                                        containerColor =
+                                            MaterialTheme.colorScheme.surfaceContainerLow,
+                                    ),
+                            ) {
+                                Text(
+                                    modifier =
+                                        Modifier.padding(16.dp),
+                                    text = description,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                )
+                            }
                         }
                         val coordinateCount = finding.finding.coordinates.size
                         Text(
-                            modifier = Modifier.padding(top = 16.dp),
                             text =
                                 pluralStringResource(
                                     Res.plurals.coordinate_count,
                                     coordinateCount,
                                     coordinateCount,
                                 ),
-                            style = MaterialTheme.typography.bodySmall,
+                            style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }

--- a/feat/findings/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driving/impl/internal/findingDetail/ui/components/ImportanceLabel.kt
+++ b/feat/findings/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driving/impl/internal/findingDetail/ui/components/ImportanceLabel.kt
@@ -13,7 +13,6 @@
 package cz.adamec.timotej.snag.findings.fe.driving.impl.internal.findingDetail.ui.components
 
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Surface
@@ -40,14 +39,14 @@ internal fun ImportanceLabel(
 ) {
     val importanceColor =
         when (importance) {
-            Importance.HIGH -> MaterialTheme.colorScheme.error
-            Importance.MEDIUM -> MaterialTheme.colorScheme.tertiary
-            Importance.LOW -> MaterialTheme.colorScheme.surfaceVariant
+            Importance.HIGH -> MaterialTheme.colorScheme.errorContainer
+            Importance.MEDIUM -> MaterialTheme.colorScheme.tertiaryContainer
+            Importance.LOW -> MaterialTheme.colorScheme.surfaceContainerHigh
         }
     val importanceTextColor =
         when (importance) {
-            Importance.HIGH -> MaterialTheme.colorScheme.onError
-            Importance.MEDIUM -> MaterialTheme.colorScheme.onTertiary
+            Importance.HIGH -> MaterialTheme.colorScheme.onErrorContainer
+            Importance.MEDIUM -> MaterialTheme.colorScheme.onTertiaryContainer
             Importance.LOW -> MaterialTheme.colorScheme.onSurfaceVariant
         }
     val importanceText =
@@ -74,12 +73,12 @@ internal fun ImportanceLabel(
     ) {
         Surface(
             color = importanceColor,
-            shape = RoundedCornerShape(4.dp),
+            shape = MaterialTheme.shapes.small,
         ) {
             Text(
-                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
                 text = importanceText,
-                style = MaterialTheme.typography.labelSmall,
+                style = MaterialTheme.typography.labelMedium,
                 color = importanceTextColor,
             )
         }

--- a/feat/findings/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driving/impl/internal/findingDetail/ui/components/TermLabel.kt
+++ b/feat/findings/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driving/impl/internal/findingDetail/ui/components/TermLabel.kt
@@ -13,7 +13,6 @@
 package cz.adamec.timotej.snag.findings.fe.driving.impl.internal.findingDetail.ui.components
 
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Surface
@@ -63,12 +62,12 @@ internal fun TermLabel(
     ) {
         Surface(
             color = MaterialTheme.colorScheme.secondaryContainer,
-            shape = RoundedCornerShape(4.dp),
+            shape = MaterialTheme.shapes.small,
         ) {
             Text(
-                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
                 text = termText,
-                style = MaterialTheme.typography.labelSmall,
+                style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSecondaryContainer,
             )
         }


### PR DESCRIPTION
## Problem Statement
The finding detail screen used flat, utilitarian styling that didn't align with Material 3 Expressive design philosophy — small sharp-cornered badges, tiny icons, and plain text layout.

## Solution
- **Tinted icon container**: Finding type icon now sits in a 40dp rounded container with a subtle tinted background (12% alpha of the pin color)
- **Pill-shaped badges**: ImportanceLabel and TermLabel use `MaterialTheme.shapes.small` instead of `RoundedCornerShape(4.dp)`, with larger padding and `labelMedium` typography
- **Container color palette**: Importance badges use softer container variants (`errorContainer`/`tertiaryContainer`) instead of raw color tokens
- **Description card**: Description wrapped in an `ElevatedCard` with `surfaceContainerLow` background for visual depth
- **Consistent spacing**: Content Column uses `Arrangement.spacedBy(16.dp)` for uniform vertical rhythm

## Test Coverage
- Build compiles successfully (`compileKotlinIosSimulatorArm64`)
- ktlint passes with no violations
- Existing previews cover all states (loaded classic, loaded note, loading, not found)

## References
Material 3 Expressive design guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)