### PR TITLE
feat: indicate online fetching status in SyncStatusBar

### DIFF
--- a/feat/clients/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/clients/fe/app/impl/internal/PullClientChangesUseCaseImpl.kt
+++ b/feat/clients/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/clients/fe/app/impl/internal/PullClientChangesUseCaseImpl.kt
@@ -21,6 +21,7 @@ import cz.adamec.timotej.snag.lib.core.common.Timestamp
 import cz.adamec.timotej.snag.lib.core.common.TimestampProvider
 import cz.adamec.timotej.snag.lib.core.fe.OnlineDataResult
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.GetLastPullSyncedAtTimestampUseCase
+import cz.adamec.timotej.snag.lib.sync.fe.app.api.PullSyncTracker
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.SetLastPullSyncedAtTimestampUseCase
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.SyncCoordinator
 
@@ -31,45 +32,47 @@ internal class PullClientChangesUseCaseImpl(
     private val setLastPullSyncedAtTimestampUseCase: SetLastPullSyncedAtTimestampUseCase,
     private val syncCoordinator: SyncCoordinator,
     private val timestampProvider: TimestampProvider,
+    private val pullSyncTracker: PullSyncTracker,
 ) : PullClientChangesUseCase {
     @Suppress("LabeledExpression")
-    override suspend operator fun invoke() {
-        LH.logger.d { "Starting pull sync for clients." }
-        syncCoordinator.withFlushedQueue { wasFlushingSuccessful ->
-            if (!wasFlushingSuccessful) {
-                LH.logger.w { "Flushing sync queue was not successful, skipping pull sync for clients." }
-                return@withFlushedQueue
-            }
-            val since = getLastPullSyncedAtTimestampUseCase(CLIENT_SYNC_ENTITY_TYPE) ?: Timestamp(0)
-            val now = timestampProvider.getNowTimestamp()
-            LH.logger.d { "Pulling client changes since=$since, now=$now." }
-
-            when (val result = clientsApi.getClientsModifiedSince(since)) {
-                is OnlineDataResult.Failure -> {
-                    LH.logger.w { "Error pulling client changes." }
+    override suspend operator fun invoke() =
+        pullSyncTracker.track {
+            LH.logger.d { "Starting pull sync for clients." }
+            syncCoordinator.withFlushedQueue { wasFlushingSuccessful ->
+                if (!wasFlushingSuccessful) {
+                    LH.logger.w { "Flushing sync queue was not successful, skipping pull sync for clients." }
+                    return@withFlushedQueue
                 }
-                is OnlineDataResult.Success -> {
-                    val changes = result.data
-                    LH.logger.d { "Received ${changes.size} client change(s)." }
-                    changes.forEach { syncResult ->
-                        when (syncResult) {
-                            is ClientSyncResult.Deleted -> {
-                                LH.logger.d { "Processing deleted client ${syncResult.id}." }
-                                clientsDb.deleteClient(syncResult.id)
-                            }
-                            is ClientSyncResult.Updated -> {
-                                LH.logger.d { "Processing updated client ${syncResult.client.client.id}." }
-                                clientsDb.saveClient(syncResult.client)
+                val since = getLastPullSyncedAtTimestampUseCase(CLIENT_SYNC_ENTITY_TYPE) ?: Timestamp(0)
+                val now = timestampProvider.getNowTimestamp()
+                LH.logger.d { "Pulling client changes since=$since, now=$now." }
+
+                when (val result = clientsApi.getClientsModifiedSince(since)) {
+                    is OnlineDataResult.Failure -> {
+                        LH.logger.w { "Error pulling client changes." }
+                    }
+                    is OnlineDataResult.Success -> {
+                        val changes = result.data
+                        LH.logger.d { "Received ${changes.size} client change(s)." }
+                        changes.forEach { syncResult ->
+                            when (syncResult) {
+                                is ClientSyncResult.Deleted -> {
+                                    LH.logger.d { "Processing deleted client ${syncResult.id}." }
+                                    clientsDb.deleteClient(syncResult.id)
+                                }
+                                is ClientSyncResult.Updated -> {
+                                    LH.logger.d { "Processing updated client ${syncResult.client.client.id}." }
+                                    clientsDb.saveClient(syncResult.client)
+                                }
                             }
                         }
+                        setLastPullSyncedAtTimestampUseCase(
+                            entityType = CLIENT_SYNC_ENTITY_TYPE,
+                            timestamp = now,
+                        )
+                        LH.logger.d { "Pull sync for clients completed, updated lastSyncedAt=$now." }
                     }
-                    setLastPullSyncedAtTimestampUseCase(
-                        entityType = CLIENT_SYNC_ENTITY_TYPE,
-                        timestamp = now,
-                    )
-                    LH.logger.d { "Pull sync for clients completed, updated lastSyncedAt=$now." }
                 }
             }
         }
-    }
 }

--- a/feat/clients/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/clients/fe/driving/impl/internal/clients/ui/ClientsContent.kt
+++ b/feat/clients/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/clients/fe/driving/impl/internal/clients/ui/ClientsContent.kt
@@ -12,19 +12,14 @@
 
 package cz.adamec.timotej.snag.clients.fe.driving.impl.internal.clients.ui
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.material3.LoadingIndicator
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import cz.adamec.timotej.snag.clients.fe.driving.impl.internal.clients.ui.components.ClientListItem
@@ -81,18 +76,6 @@ internal fun ClientsContent(
                     onClick = { onClientClick(client.client.id) },
                     client = client,
                 )
-            }
-            item {
-                AnimatedVisibility(
-                    visible = state.isLoading,
-                    exit = fadeOut(),
-                ) {
-                    Box(
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        LoadingIndicator()
-                    }
-                }
             }
         }
     }

--- a/feat/clients/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/clients/fe/driving/impl/internal/clients/vm/ClientsUiState.kt
+++ b/feat/clients/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/clients/fe/driving/impl/internal/clients/vm/ClientsUiState.kt
@@ -20,5 +20,4 @@ import kotlinx.collections.immutable.persistentListOf
 @Immutable
 data class ClientsUiState(
     val clients: ImmutableList<FrontendClient> = persistentListOf(),
-    val isLoading: Boolean = false,
 )

--- a/feat/clients/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/clients/fe/driving/impl/internal/clients/vm/ClientsViewModel.kt
+++ b/feat/clients/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/clients/fe/driving/impl/internal/clients/vm/ClientsViewModel.kt
@@ -44,11 +44,6 @@ internal class ClientsViewModel(
             .map { clientsDataResult ->
                 when (clientsDataResult) {
                     is OfflineFirstDataResult.ProgrammerError -> {
-                        _state.update {
-                            it.copy(
-                                isLoading = false,
-                            )
-                        }
                         errorEventsChannel.send(UiError.Unknown)
                     }
 
@@ -56,7 +51,6 @@ internal class ClientsViewModel(
                         _state.update {
                             it.copy(
                                 clients = clientsDataResult.data.toPersistentList(),
-                                isLoading = false,
                             )
                         }
                     }

--- a/feat/findings/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/app/impl/internal/PullFindingChangesUseCaseImpl.kt
+++ b/feat/findings/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/app/impl/internal/PullFindingChangesUseCaseImpl.kt
@@ -21,6 +21,7 @@ import cz.adamec.timotej.snag.lib.core.common.Timestamp
 import cz.adamec.timotej.snag.lib.core.common.TimestampProvider
 import cz.adamec.timotej.snag.lib.core.fe.OnlineDataResult
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.GetLastPullSyncedAtTimestampUseCase
+import cz.adamec.timotej.snag.lib.sync.fe.app.api.PullSyncTracker
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.SetLastPullSyncedAtTimestampUseCase
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.SyncCoordinator
 import kotlin.uuid.Uuid
@@ -32,52 +33,54 @@ internal class PullFindingChangesUseCaseImpl(
     private val setLastPullSyncedAtTimestampUseCase: SetLastPullSyncedAtTimestampUseCase,
     private val syncCoordinator: SyncCoordinator,
     private val timestampProvider: TimestampProvider,
+    private val pullSyncTracker: PullSyncTracker,
 ) : PullFindingChangesUseCase {
     @Suppress("LabeledExpression")
-    override suspend operator fun invoke(structureId: Uuid) {
-        LH.logger.d { "Starting pull sync for findings in structure $structureId." }
-        syncCoordinator.withFlushedQueue { wasFlushingSuccessful ->
-            if (!wasFlushingSuccessful) {
-                LH.logger.w {
-                    "Flushing sync queue was not successful, skipping pull sync for findings in structure $structureId."
+    override suspend operator fun invoke(structureId: Uuid) =
+        pullSyncTracker.track {
+            LH.logger.d { "Starting pull sync for findings in structure $structureId." }
+            syncCoordinator.withFlushedQueue { wasFlushingSuccessful ->
+                if (!wasFlushingSuccessful) {
+                    LH.logger.w {
+                        "Flushing sync queue was not successful, skipping pull sync for findings in structure $structureId."
+                    }
+                    return@withFlushedQueue
                 }
-                return@withFlushedQueue
-            }
-            val since =
-                getLastPullSyncedAtTimestampUseCase(
-                    entityType = FINDING_SYNC_ENTITY_TYPE,
-                    scopeId = structureId.toString(),
-                ) ?: Timestamp(0)
-            val now = timestampProvider.getNowTimestamp()
-            LH.logger.d { "Pulling finding changes for structure $structureId since=$since, now=$now." }
+                val since =
+                    getLastPullSyncedAtTimestampUseCase(
+                        entityType = FINDING_SYNC_ENTITY_TYPE,
+                        scopeId = structureId.toString(),
+                    ) ?: Timestamp(0)
+                val now = timestampProvider.getNowTimestamp()
+                LH.logger.d { "Pulling finding changes for structure $structureId since=$since, now=$now." }
 
-            when (val result = findingsApi.getFindingsModifiedSince(structureId, since)) {
-                is OnlineDataResult.Failure -> {
-                    LH.logger.w { "Error pulling finding changes for structure $structureId." }
-                }
-                is OnlineDataResult.Success -> {
-                    val changes = result.data
-                    LH.logger.d { "Received ${changes.size} finding change(s) for structure $structureId." }
-                    changes.forEach { syncResult ->
-                        when (syncResult) {
-                            is FindingSyncResult.Deleted -> {
-                                LH.logger.d { "Processing deleted finding ${syncResult.id}." }
-                                findingsDb.deleteFinding(syncResult.id)
-                            }
-                            is FindingSyncResult.Updated -> {
-                                LH.logger.d { "Processing updated finding ${syncResult.finding.finding.id}." }
-                                findingsDb.saveFinding(syncResult.finding)
+                when (val result = findingsApi.getFindingsModifiedSince(structureId, since)) {
+                    is OnlineDataResult.Failure -> {
+                        LH.logger.w { "Error pulling finding changes for structure $structureId." }
+                    }
+                    is OnlineDataResult.Success -> {
+                        val changes = result.data
+                        LH.logger.d { "Received ${changes.size} finding change(s) for structure $structureId." }
+                        changes.forEach { syncResult ->
+                            when (syncResult) {
+                                is FindingSyncResult.Deleted -> {
+                                    LH.logger.d { "Processing deleted finding ${syncResult.id}." }
+                                    findingsDb.deleteFinding(syncResult.id)
+                                }
+                                is FindingSyncResult.Updated -> {
+                                    LH.logger.d { "Processing updated finding ${syncResult.finding.finding.id}." }
+                                    findingsDb.saveFinding(syncResult.finding)
+                                }
                             }
                         }
+                        setLastPullSyncedAtTimestampUseCase(
+                            entityType = FINDING_SYNC_ENTITY_TYPE,
+                            timestamp = now,
+                            scopeId = structureId.toString(),
+                        )
+                        LH.logger.d { "Pull sync for findings in structure $structureId completed, updated lastSyncedAt=$now." }
                     }
-                    setLastPullSyncedAtTimestampUseCase(
-                        entityType = FINDING_SYNC_ENTITY_TYPE,
-                        timestamp = now,
-                        scopeId = structureId.toString(),
-                    )
-                    LH.logger.d { "Pull sync for findings in structure $structureId completed, updated lastSyncedAt=$now." }
                 }
             }
         }
-    }
 }

--- a/feat/findings/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driving/impl/internal/findingDetail/ui/FindingDetailContent.kt
+++ b/feat/findings/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driving/impl/internal/findingDetail/ui/FindingDetailContent.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.ContainedLoadingIndicator
 import androidx.compose.material3.FloatingToolbarDefaults
 import androidx.compose.material3.HorizontalFloatingToolbar
 import androidx.compose.material3.Icon
@@ -87,14 +86,7 @@ internal fun FindingDetailContent(
     modifier: Modifier = Modifier,
 ) {
     when (state.status) {
-        FindingDetailUiStatus.LOADING -> {
-            Box(
-                modifier = modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center,
-            ) {
-                ContainedLoadingIndicator()
-            }
-        }
+        FindingDetailUiStatus.LOADING -> {}
 
         FindingDetailUiStatus.NOT_FOUND -> {
             Box(

--- a/feat/findings/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driving/impl/internal/findingsList/ui/FindingsListContent.kt
+++ b/feat/findings/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driving/impl/internal/findingsList/ui/FindingsListContent.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.ContainedLoadingIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
@@ -53,15 +52,6 @@ internal fun FindingsListContent(
     modifier: Modifier = Modifier,
 ) {
     when (state.status) {
-        FindingsListUiStatus.LOADING -> {
-            Box(
-                modifier = modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center,
-            ) {
-                ContainedLoadingIndicator()
-            }
-        }
-
         FindingsListUiStatus.ERROR -> {
             Box(
                 modifier = modifier.fillMaxSize(),

--- a/feat/findings/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driving/impl/internal/findingsList/vm/FindingsListUiState.kt
+++ b/feat/findings/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driving/impl/internal/findingsList/vm/FindingsListUiState.kt
@@ -15,12 +15,11 @@ package cz.adamec.timotej.snag.findings.fe.driving.impl.internal.findingsList.vm
 import cz.adamec.timotej.snag.feat.findings.fe.model.FrontendFinding
 
 internal data class FindingsListUiState(
-    val status: FindingsListUiStatus = FindingsListUiStatus.LOADING,
+    val status: FindingsListUiStatus = FindingsListUiStatus.LOADED,
     val findings: List<FrontendFinding> = emptyList(),
 )
 
 internal enum class FindingsListUiStatus {
     ERROR,
-    LOADING,
     LOADED,
 }

--- a/feat/findings/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driving/impl/internal/findingsList/vm/FindingsListViewModel.kt
+++ b/feat/findings/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/findings/fe/driving/impl/internal/findingsList/vm/FindingsListViewModel.kt
@@ -54,7 +54,6 @@ internal class FindingsListViewModel(
                     is OfflineFirstDataResult.Success -> {
                         _state.update {
                             it.copy(
-                                status = FindingsListUiStatus.LOADED,
                                 findings = result.data,
                             )
                         }

--- a/feat/inspections/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/feat/inspections/fe/app/impl/internal/PullInspectionChangesUseCaseImpl.kt
+++ b/feat/inspections/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/feat/inspections/fe/app/impl/internal/PullInspectionChangesUseCaseImpl.kt
@@ -21,6 +21,7 @@ import cz.adamec.timotej.snag.lib.core.common.Timestamp
 import cz.adamec.timotej.snag.lib.core.common.TimestampProvider
 import cz.adamec.timotej.snag.lib.core.fe.OnlineDataResult
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.GetLastPullSyncedAtTimestampUseCase
+import cz.adamec.timotej.snag.lib.sync.fe.app.api.PullSyncTracker
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.SetLastPullSyncedAtTimestampUseCase
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.SyncCoordinator
 import kotlin.uuid.Uuid
@@ -32,52 +33,54 @@ internal class PullInspectionChangesUseCaseImpl(
     private val setLastPullSyncedAtTimestampUseCase: SetLastPullSyncedAtTimestampUseCase,
     private val syncCoordinator: SyncCoordinator,
     private val timestampProvider: TimestampProvider,
+    private val pullSyncTracker: PullSyncTracker,
 ) : PullInspectionChangesUseCase {
     @Suppress("LabeledExpression")
-    override suspend operator fun invoke(projectId: Uuid) {
-        LH.logger.d { "Starting pull sync for inspections in project $projectId." }
-        syncCoordinator.withFlushedQueue { wasFlushingSuccessful ->
-            if (!wasFlushingSuccessful) {
-                LH.logger.w {
-                    "Flushing sync queue was not successful, skipping pull sync for for inspections in project $projectId."
+    override suspend operator fun invoke(projectId: Uuid) =
+        pullSyncTracker.track {
+            LH.logger.d { "Starting pull sync for inspections in project $projectId." }
+            syncCoordinator.withFlushedQueue { wasFlushingSuccessful ->
+                if (!wasFlushingSuccessful) {
+                    LH.logger.w {
+                        "Flushing sync queue was not successful, skipping pull sync for for inspections in project $projectId."
+                    }
+                    return@withFlushedQueue
                 }
-                return@withFlushedQueue
-            }
-            val since =
-                getLastPullSyncedAtTimestampUseCase(
-                    entityType = INSPECTION_SYNC_ENTITY_TYPE,
-                    scopeId = projectId.toString(),
-                ) ?: Timestamp(0)
-            val now = timestampProvider.getNowTimestamp()
-            LH.logger.d { "Pulling inspection changes for project $projectId since=$since, now=$now." }
+                val since =
+                    getLastPullSyncedAtTimestampUseCase(
+                        entityType = INSPECTION_SYNC_ENTITY_TYPE,
+                        scopeId = projectId.toString(),
+                    ) ?: Timestamp(0)
+                val now = timestampProvider.getNowTimestamp()
+                LH.logger.d { "Pulling inspection changes for project $projectId since=$since, now=$now." }
 
-            when (val result = inspectionsApi.getInspectionsModifiedSince(projectId, since)) {
-                is OnlineDataResult.Failure -> {
-                    LH.logger.w { "Error pulling inspection changes for project $projectId." }
-                }
-                is OnlineDataResult.Success -> {
-                    val changes = result.data
-                    LH.logger.d { "Received ${changes.size} inspection change(s) for project $projectId." }
-                    changes.forEach { syncResult ->
-                        when (syncResult) {
-                            is InspectionSyncResult.Deleted -> {
-                                LH.logger.d { "Processing deleted inspection ${syncResult.id}." }
-                                inspectionsDb.deleteInspection(syncResult.id)
-                            }
-                            is InspectionSyncResult.Updated -> {
-                                LH.logger.d { "Processing updated inspection ${syncResult.inspection.inspection.id}." }
-                                inspectionsDb.saveInspection(syncResult.inspection)
+                when (val result = inspectionsApi.getInspectionsModifiedSince(projectId, since)) {
+                    is OnlineDataResult.Failure -> {
+                        LH.logger.w { "Error pulling inspection changes for project $projectId." }
+                    }
+                    is OnlineDataResult.Success -> {
+                        val changes = result.data
+                        LH.logger.d { "Received ${changes.size} inspection change(s) for project $projectId." }
+                        changes.forEach { syncResult ->
+                            when (syncResult) {
+                                is InspectionSyncResult.Deleted -> {
+                                    LH.logger.d { "Processing deleted inspection ${syncResult.id}." }
+                                    inspectionsDb.deleteInspection(syncResult.id)
+                                }
+                                is InspectionSyncResult.Updated -> {
+                                    LH.logger.d { "Processing updated inspection ${syncResult.inspection.inspection.id}." }
+                                    inspectionsDb.saveInspection(syncResult.inspection)
+                                }
                             }
                         }
+                        setLastPullSyncedAtTimestampUseCase(
+                            entityType = INSPECTION_SYNC_ENTITY_TYPE,
+                            timestamp = now,
+                            scopeId = projectId.toString(),
+                        )
+                        LH.logger.d { "Pull sync for inspections in project $projectId completed, updated lastSyncedAt=$now." }
                     }
-                    setLastPullSyncedAtTimestampUseCase(
-                        entityType = INSPECTION_SYNC_ENTITY_TYPE,
-                        timestamp = now,
-                        scopeId = projectId.toString(),
-                    )
-                    LH.logger.d { "Pull sync for inspections in project $projectId completed, updated lastSyncedAt=$now." }
                 }
             }
         }
-    }
 }

--- a/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/PullProjectChangesUseCaseImpl.kt
+++ b/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/PullProjectChangesUseCaseImpl.kt
@@ -17,6 +17,7 @@ import cz.adamec.timotej.snag.lib.core.common.Timestamp
 import cz.adamec.timotej.snag.lib.core.common.TimestampProvider
 import cz.adamec.timotej.snag.lib.core.fe.OnlineDataResult
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.GetLastPullSyncedAtTimestampUseCase
+import cz.adamec.timotej.snag.lib.sync.fe.app.api.PullSyncTracker
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.SetLastPullSyncedAtTimestampUseCase
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.SyncCoordinator
 import cz.adamec.timotej.snag.projects.fe.app.api.PullProjectChangesUseCase
@@ -35,47 +36,49 @@ internal class PullProjectChangesUseCaseImpl(
     private val setLastPullSyncedAtTimestampUseCase: SetLastPullSyncedAtTimestampUseCase,
     private val syncCoordinator: SyncCoordinator,
     private val timestampProvider: TimestampProvider,
+    private val pullSyncTracker: PullSyncTracker,
 ) : PullProjectChangesUseCase {
     @Suppress("LabeledExpression")
-    override suspend operator fun invoke() {
-        LH.logger.d { "Starting pull sync for projects." }
-        syncCoordinator.withFlushedQueue { wasFlushingSuccessful ->
-            if (!wasFlushingSuccessful) {
-                LH.logger.w("Flushing sync queue was not successful, skipping pull sync for projects.")
-                return@withFlushedQueue
-            }
-            val since = getLastPullSyncedAtTimestampUseCase(PROJECT_SYNC_ENTITY_TYPE) ?: Timestamp(0)
-            val now = timestampProvider.getNowTimestamp()
-            LH.logger.d { "Pulling project changes since=$since, now=$now." }
-
-            when (val result = projectsApi.getProjectsModifiedSince(since)) {
-                is OnlineDataResult.Failure -> {
-                    LH.logger.w { "Error pulling project changes." }
+    override suspend operator fun invoke() =
+        pullSyncTracker.track {
+            LH.logger.d { "Starting pull sync for projects." }
+            syncCoordinator.withFlushedQueue { wasFlushingSuccessful ->
+                if (!wasFlushingSuccessful) {
+                    LH.logger.w("Flushing sync queue was not successful, skipping pull sync for projects.")
+                    return@withFlushedQueue
                 }
-                is OnlineDataResult.Success -> {
-                    val changes = result.data
-                    LH.logger.d { "Received ${changes.size} project change(s)." }
-                    changes.forEach { syncResult ->
-                        when (syncResult) {
-                            is ProjectSyncResult.Deleted -> {
-                                LH.logger.d { "Processing deleted project ${syncResult.id}." }
-                                cascadeDeleteLocalStructuresByProjectIdUseCase(syncResult.id)
-                                cascadeDeleteLocalInspectionsByProjectIdUseCase(syncResult.id)
-                                projectsDb.deleteProject(syncResult.id)
-                            }
-                            is ProjectSyncResult.Updated -> {
-                                LH.logger.d { "Processing updated project ${syncResult.project.project.id}." }
-                                projectsDb.saveProject(syncResult.project)
+                val since = getLastPullSyncedAtTimestampUseCase(PROJECT_SYNC_ENTITY_TYPE) ?: Timestamp(0)
+                val now = timestampProvider.getNowTimestamp()
+                LH.logger.d { "Pulling project changes since=$since, now=$now." }
+
+                when (val result = projectsApi.getProjectsModifiedSince(since)) {
+                    is OnlineDataResult.Failure -> {
+                        LH.logger.w { "Error pulling project changes." }
+                    }
+                    is OnlineDataResult.Success -> {
+                        val changes = result.data
+                        LH.logger.d { "Received ${changes.size} project change(s)." }
+                        changes.forEach { syncResult ->
+                            when (syncResult) {
+                                is ProjectSyncResult.Deleted -> {
+                                    LH.logger.d { "Processing deleted project ${syncResult.id}." }
+                                    cascadeDeleteLocalStructuresByProjectIdUseCase(syncResult.id)
+                                    cascadeDeleteLocalInspectionsByProjectIdUseCase(syncResult.id)
+                                    projectsDb.deleteProject(syncResult.id)
+                                }
+                                is ProjectSyncResult.Updated -> {
+                                    LH.logger.d { "Processing updated project ${syncResult.project.project.id}." }
+                                    projectsDb.saveProject(syncResult.project)
+                                }
                             }
                         }
+                        setLastPullSyncedAtTimestampUseCase(
+                            entityType = PROJECT_SYNC_ENTITY_TYPE,
+                            timestamp = now,
+                        )
+                        LH.logger.d { "Pull sync for projects completed, updated lastSyncedAt=$now." }
                     }
-                    setLastPullSyncedAtTimestampUseCase(
-                        entityType = PROJECT_SYNC_ENTITY_TYPE,
-                        timestamp = now,
-                    )
-                    LH.logger.d { "Pull sync for projects completed, updated lastSyncedAt=$now." }
                 }
             }
         }
-    }
 }

--- a/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetails/ui/ProjectDetailsContent.kt
+++ b/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetails/ui/ProjectDetailsContent.kt
@@ -12,8 +12,6 @@
 
 package cz.adamec.timotej.snag.projects.fe.driving.impl.internal.projectDetails.ui
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -35,7 +33,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.ContainedLoadingIndicator
 import androidx.compose.material3.HorizontalFloatingToolbar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -63,10 +60,8 @@ import cz.adamec.timotej.snag.lib.design.fe.scaffold.BackNavigationIcon
 import cz.adamec.timotej.snag.lib.design.fe.scaffold.CollapsableTopAppBarScaffold
 import cz.adamec.timotej.snag.lib.design.fe.theme.SnagPreview
 import cz.adamec.timotej.snag.projects.business.Project
-import cz.adamec.timotej.snag.projects.fe.driving.impl.internal.projectDetails.vm.InspectionsUiStatus
 import cz.adamec.timotej.snag.projects.fe.driving.impl.internal.projectDetails.vm.ProjectDetailsUiState
 import cz.adamec.timotej.snag.projects.fe.driving.impl.internal.projectDetails.vm.ProjectDetailsUiStatus
-import cz.adamec.timotej.snag.projects.fe.driving.impl.internal.projectDetails.vm.StructuresUiStatus
 import cz.adamec.timotej.snag.projects.fe.model.FrontendProject
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -121,12 +116,7 @@ internal fun ProjectDetailsContent(
                 )
             }
 
-            ProjectDetailsUiStatus.LOADING -> {
-                ContainedLoadingIndicator(
-                    modifier = Modifier.align(Alignment.Center),
-                )
-            }
-
+            ProjectDetailsUiStatus.LOADING,
             ProjectDetailsUiStatus.LOADED,
             ProjectDetailsUiStatus.DELETED,
             -> {
@@ -255,18 +245,6 @@ private fun LoadedProjectDetailsContent(
                                 },
                             )
                         }
-                        item {
-                            AnimatedVisibility(
-                                visible = state.inspectionStatus == InspectionsUiStatus.LOADING,
-                                exit = fadeOut(),
-                            ) {
-                                Box(
-                                    contentAlignment = Alignment.Center,
-                                ) {
-                                    LoadingIndicator()
-                                }
-                            }
-                        }
                     }
                 }
                 item {
@@ -332,18 +310,6 @@ private fun LoadedProjectDetailsContent(
                                     },
                                 )
                             }
-                        }
-                    }
-                }
-                item {
-                    AnimatedVisibility(
-                        visible = state.structureStatus == StructuresUiStatus.LOADING,
-                        exit = fadeOut(),
-                    ) {
-                        Box(
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            LoadingIndicator()
                         }
                     }
                 }

--- a/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetails/vm/ProjectDetailsUiState.kt
+++ b/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetails/vm/ProjectDetailsUiState.kt
@@ -20,8 +20,8 @@ import kotlinx.collections.immutable.persistentListOf
 
 internal data class ProjectDetailsUiState(
     val projectStatus: ProjectDetailsUiStatus = ProjectDetailsUiStatus.LOADING,
-    val structureStatus: StructuresUiStatus = StructuresUiStatus.LOADING,
-    val inspectionStatus: InspectionsUiStatus = InspectionsUiStatus.LOADING,
+    val structureStatus: StructuresUiStatus = StructuresUiStatus.LOADED,
+    val inspectionStatus: InspectionsUiStatus = InspectionsUiStatus.LOADED,
     val isBeingDeleted: Boolean = false,
     val isDownloadingReport: Boolean = false,
     val isClosingOrReopening: Boolean = false,
@@ -46,12 +46,10 @@ internal enum class ProjectDetailsUiStatus {
 
 internal enum class StructuresUiStatus {
     ERROR,
-    LOADING,
     LOADED,
 }
 
 internal enum class InspectionsUiStatus {
     ERROR,
-    LOADING,
     LOADED,
 }

--- a/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetails/vm/ProjectDetailsViewModel.kt
+++ b/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projectDetails/vm/ProjectDetailsViewModel.kt
@@ -117,7 +117,6 @@ internal class ProjectDetailsViewModel(
                     is OfflineFirstDataResult.Success -> {
                         _state.update {
                             it.copy(
-                                structureStatus = StructuresUiStatus.LOADED,
                                 structures = result.data.toImmutableList(),
                             )
                         }
@@ -141,7 +140,6 @@ internal class ProjectDetailsViewModel(
                     is OfflineFirstDataResult.Success -> {
                         _state.update {
                             it.copy(
-                                inspectionStatus = InspectionsUiStatus.LOADED,
                                 inspections = result.data.toImmutableList(),
                             )
                         }

--- a/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projects/ui/ProjectsContent.kt
+++ b/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projects/ui/ProjectsContent.kt
@@ -12,19 +12,14 @@
 
 package cz.adamec.timotej.snag.projects.fe.driving.impl.internal.projects.ui
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.material3.LoadingIndicator
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import cz.adamec.timotej.snag.lib.design.fe.button.AdaptiveTonalButton
@@ -81,18 +76,6 @@ internal fun ProjectsContent(
                     onClick = { onProjectClick(project.project.id) },
                     project = project,
                 )
-            }
-            item {
-                AnimatedVisibility(
-                    visible = state.isLoading,
-                    exit = fadeOut(),
-                ) {
-                    Box(
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        LoadingIndicator()
-                    }
-                }
             }
         }
     }

--- a/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projects/vm/ProjectsUiState.kt
+++ b/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projects/vm/ProjectsUiState.kt
@@ -20,5 +20,4 @@ import kotlinx.collections.immutable.persistentListOf
 @Immutable
 data class ProjectsUiState(
     val projects: ImmutableList<FrontendProject> = persistentListOf(),
-    val isLoading: Boolean = false,
 )

--- a/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projects/vm/ProjectsViewModel.kt
+++ b/feat/projects/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/impl/internal/projects/vm/ProjectsViewModel.kt
@@ -44,11 +44,6 @@ internal class ProjectsViewModel(
             .map { projectsDataResult ->
                 when (projectsDataResult) {
                     is OfflineFirstDataResult.ProgrammerError -> {
-                        _state.update {
-                            it.copy(
-                                isLoading = false,
-                            )
-                        }
                         errorEventsChannel.send(UiError.Unknown)
                     }
 
@@ -56,7 +51,6 @@ internal class ProjectsViewModel(
                         _state.update {
                             it.copy(
                                 projects = projectsDataResult.data.toPersistentList(),
-                                isLoading = false,
                             )
                         }
                     }

--- a/feat/structures/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/app/impl/internal/PullStructureChangesUseCaseImpl.kt
+++ b/feat/structures/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/app/impl/internal/PullStructureChangesUseCaseImpl.kt
@@ -17,6 +17,7 @@ import cz.adamec.timotej.snag.lib.core.common.Timestamp
 import cz.adamec.timotej.snag.lib.core.common.TimestampProvider
 import cz.adamec.timotej.snag.lib.core.fe.OnlineDataResult
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.GetLastPullSyncedAtTimestampUseCase
+import cz.adamec.timotej.snag.lib.sync.fe.app.api.PullSyncTracker
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.SetLastPullSyncedAtTimestampUseCase
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.SyncCoordinator
 import cz.adamec.timotej.snag.structures.fe.app.api.PullStructureChangesUseCase
@@ -34,55 +35,57 @@ internal class PullStructureChangesUseCaseImpl(
     private val setLastPullSyncedAtTimestampUseCase: SetLastPullSyncedAtTimestampUseCase,
     private val syncCoordinator: SyncCoordinator,
     private val timestampProvider: TimestampProvider,
+    private val pullSyncTracker: PullSyncTracker,
 ) : PullStructureChangesUseCase {
     @Suppress("LabeledExpression")
-    override suspend operator fun invoke(projectId: Uuid) {
-        LH.logger.d { "Starting pull sync for structures in project $projectId." }
-        syncCoordinator.withFlushedQueue { wasFlushingSuccessful ->
-            if (!wasFlushingSuccessful) {
-                LH.logger.w {
-                    "Flushing sync queue was not successful, skipping pull sync for structures in project $projectId."
+    override suspend operator fun invoke(projectId: Uuid) =
+        pullSyncTracker.track {
+            LH.logger.d { "Starting pull sync for structures in project $projectId." }
+            syncCoordinator.withFlushedQueue { wasFlushingSuccessful ->
+                if (!wasFlushingSuccessful) {
+                    LH.logger.w {
+                        "Flushing sync queue was not successful, skipping pull sync for structures in project $projectId."
+                    }
+                    return@withFlushedQueue
                 }
-                return@withFlushedQueue
-            }
-            val since =
-                getLastPullSyncedAtTimestampUseCase(
-                    entityType = STRUCTURE_SYNC_ENTITY_TYPE,
-                    scopeId = projectId.toString(),
-                ) ?: Timestamp(0)
-            val now = timestampProvider.getNowTimestamp()
-            LH.logger.d { "Pulling structure changes for project $projectId since=$since, now=$now." }
+                val since =
+                    getLastPullSyncedAtTimestampUseCase(
+                        entityType = STRUCTURE_SYNC_ENTITY_TYPE,
+                        scopeId = projectId.toString(),
+                    ) ?: Timestamp(0)
+                val now = timestampProvider.getNowTimestamp()
+                LH.logger.d { "Pulling structure changes for project $projectId since=$since, now=$now." }
 
-            when (val result = structuresApi.getStructuresModifiedSince(projectId, since)) {
-                is OnlineDataResult.Failure -> {
-                    LH.logger.w { "Error pulling structure changes for project $projectId." }
-                }
+                when (val result = structuresApi.getStructuresModifiedSince(projectId, since)) {
+                    is OnlineDataResult.Failure -> {
+                        LH.logger.w { "Error pulling structure changes for project $projectId." }
+                    }
 
-                is OnlineDataResult.Success -> {
-                    val changes = result.data
-                    LH.logger.d { "Received ${changes.size} structure change(s) for project $projectId." }
-                    changes.forEach { syncResult ->
-                        when (syncResult) {
-                            is StructureSyncResult.Deleted -> {
-                                LH.logger.d { "Processing deleted structure ${syncResult.id}." }
-                                cascadeDeleteLocalFindingsByStructureIdUseCase(syncResult.id)
-                                structuresDb.deleteStructure(syncResult.id)
-                            }
+                    is OnlineDataResult.Success -> {
+                        val changes = result.data
+                        LH.logger.d { "Received ${changes.size} structure change(s) for project $projectId." }
+                        changes.forEach { syncResult ->
+                            when (syncResult) {
+                                is StructureSyncResult.Deleted -> {
+                                    LH.logger.d { "Processing deleted structure ${syncResult.id}." }
+                                    cascadeDeleteLocalFindingsByStructureIdUseCase(syncResult.id)
+                                    structuresDb.deleteStructure(syncResult.id)
+                                }
 
-                            is StructureSyncResult.Updated -> {
-                                LH.logger.d { "Processing updated structure ${syncResult.structure.structure.id}." }
-                                structuresDb.saveStructure(syncResult.structure)
+                                is StructureSyncResult.Updated -> {
+                                    LH.logger.d { "Processing updated structure ${syncResult.structure.structure.id}." }
+                                    structuresDb.saveStructure(syncResult.structure)
+                                }
                             }
                         }
+                        setLastPullSyncedAtTimestampUseCase(
+                            entityType = STRUCTURE_SYNC_ENTITY_TYPE,
+                            timestamp = now,
+                            scopeId = projectId.toString(),
+                        )
+                        LH.logger.d { "Pull sync for structures in project $projectId completed, updated lastSyncedAt=$now." }
                     }
-                    setLastPullSyncedAtTimestampUseCase(
-                        entityType = STRUCTURE_SYNC_ENTITY_TYPE,
-                        timestamp = now,
-                        scopeId = projectId.toString(),
-                    )
-                    LH.logger.d { "Pull sync for structures in project $projectId completed, updated lastSyncedAt=$now." }
                 }
             }
         }
-    }
 }

--- a/feat/structures/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/internal/floorPlan/ui/StructureFloorPlanContent.kt
+++ b/feat/structures/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/internal/floorPlan/ui/StructureFloorPlanContent.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.ContainedLoadingIndicator
 import androidx.compose.material3.HorizontalFloatingToolbar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -85,11 +84,7 @@ internal fun StructureFloorPlanContent(
                 )
             }
 
-            StructureDetailsUiStatus.LOADING -> {
-                ContainedLoadingIndicator(
-                    modifier = Modifier.align(Alignment.Center),
-                )
-            }
+            StructureDetailsUiStatus.LOADING -> {}
 
             StructureDetailsUiStatus.LOADED,
             StructureDetailsUiStatus.DELETED,

--- a/feat/users/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/users/fe/app/impl/internal/PullUserChangesUseCaseImpl.kt
+++ b/feat/users/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/users/fe/app/impl/internal/PullUserChangesUseCaseImpl.kt
@@ -16,6 +16,7 @@ import cz.adamec.timotej.snag.lib.core.common.Timestamp
 import cz.adamec.timotej.snag.lib.core.common.TimestampProvider
 import cz.adamec.timotej.snag.lib.core.fe.OnlineDataResult
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.GetLastPullSyncedAtTimestampUseCase
+import cz.adamec.timotej.snag.lib.sync.fe.app.api.PullSyncTracker
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.SetLastPullSyncedAtTimestampUseCase
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.SyncCoordinator
 import cz.adamec.timotej.snag.users.fe.app.api.PullUserChangesUseCase
@@ -31,41 +32,43 @@ internal class PullUserChangesUseCaseImpl(
     private val setLastPullSyncedAtTimestampUseCase: SetLastPullSyncedAtTimestampUseCase,
     private val syncCoordinator: SyncCoordinator,
     private val timestampProvider: TimestampProvider,
+    private val pullSyncTracker: PullSyncTracker,
 ) : PullUserChangesUseCase {
     @Suppress("LabeledExpression")
-    override suspend operator fun invoke() {
-        LH.logger.d { "Starting pull sync for users." }
-        syncCoordinator.withFlushedQueue { wasFlushingSuccessful ->
-            if (!wasFlushingSuccessful) {
-                LH.logger.w("Flushing sync queue was not successful, skipping pull sync for users.")
-                return@withFlushedQueue
-            }
-            val since = getLastPullSyncedAtTimestampUseCase(USER_SYNC_ENTITY_TYPE) ?: Timestamp(0)
-            val now = timestampProvider.getNowTimestamp()
-            LH.logger.d { "Pulling user changes since=$since, now=$now." }
-
-            when (val result = usersApi.getUsersModifiedSince(since)) {
-                is OnlineDataResult.Failure -> {
-                    LH.logger.w { "Error pulling user changes." }
+    override suspend operator fun invoke() =
+        pullSyncTracker.track {
+            LH.logger.d { "Starting pull sync for users." }
+            syncCoordinator.withFlushedQueue { wasFlushingSuccessful ->
+                if (!wasFlushingSuccessful) {
+                    LH.logger.w("Flushing sync queue was not successful, skipping pull sync for users.")
+                    return@withFlushedQueue
                 }
-                is OnlineDataResult.Success -> {
-                    val changes = result.data
-                    LH.logger.d { "Received ${changes.size} user change(s)." }
-                    changes.forEach { syncResult ->
-                        when (syncResult) {
-                            is UserSyncResult.Updated -> {
-                                LH.logger.d { "Processing updated user ${syncResult.user.user.id}." }
-                                usersDb.saveUser(syncResult.user)
+                val since = getLastPullSyncedAtTimestampUseCase(USER_SYNC_ENTITY_TYPE) ?: Timestamp(0)
+                val now = timestampProvider.getNowTimestamp()
+                LH.logger.d { "Pulling user changes since=$since, now=$now." }
+
+                when (val result = usersApi.getUsersModifiedSince(since)) {
+                    is OnlineDataResult.Failure -> {
+                        LH.logger.w { "Error pulling user changes." }
+                    }
+                    is OnlineDataResult.Success -> {
+                        val changes = result.data
+                        LH.logger.d { "Received ${changes.size} user change(s)." }
+                        changes.forEach { syncResult ->
+                            when (syncResult) {
+                                is UserSyncResult.Updated -> {
+                                    LH.logger.d { "Processing updated user ${syncResult.user.user.id}." }
+                                    usersDb.saveUser(syncResult.user)
+                                }
                             }
                         }
+                        setLastPullSyncedAtTimestampUseCase(
+                            entityType = USER_SYNC_ENTITY_TYPE,
+                            timestamp = now,
+                        )
+                        LH.logger.d { "Pull sync for users completed, updated lastSyncedAt=$now." }
                     }
-                    setLastPullSyncedAtTimestampUseCase(
-                        entityType = USER_SYNC_ENTITY_TYPE,
-                        timestamp = now,
-                    )
-                    LH.logger.d { "Pull sync for users completed, updated lastSyncedAt=$now." }
                 }
             }
         }
-    }
 }

--- a/lib/sync/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/sync/fe/app/api/PullSyncTracker.kt
+++ b/lib/sync/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/sync/fe/app/api/PullSyncTracker.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.lib.sync.fe.app.api
+
+import kotlinx.coroutines.flow.StateFlow
+
+interface PullSyncTracker {
+    val isPulling: StateFlow<Boolean>
+
+    suspend fun <T> track(block: suspend () -> T): T
+}

--- a/lib/sync/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/sync/fe/app/impl/di/SyncAppModule.kt
+++ b/lib/sync/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/sync/fe/app/impl/di/SyncAppModule.kt
@@ -16,6 +16,7 @@ import cz.adamec.timotej.snag.lib.sync.fe.app.api.EnqueueSyncDeleteUseCase
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.EnqueueSyncSaveUseCase
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.GetLastPullSyncedAtTimestampUseCase
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.GetSyncStatusUseCase
+import cz.adamec.timotej.snag.lib.sync.fe.app.api.PullSyncTracker
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.SetLastPullSyncedAtTimestampUseCase
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.SyncCoordinator
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.handler.SyncOperationHandler
@@ -24,6 +25,7 @@ import cz.adamec.timotej.snag.lib.sync.fe.app.impl.internal.EnqueueSyncOperation
 import cz.adamec.timotej.snag.lib.sync.fe.app.impl.internal.EnqueueSyncSaveUseCaseImpl
 import cz.adamec.timotej.snag.lib.sync.fe.app.impl.internal.GetLastPullSyncedAtTimestampUseCaseImpl
 import cz.adamec.timotej.snag.lib.sync.fe.app.impl.internal.GetSyncStatusUseCaseImpl
+import cz.adamec.timotej.snag.lib.sync.fe.app.impl.internal.PullSyncTrackerImpl
 import cz.adamec.timotej.snag.lib.sync.fe.app.impl.internal.SetLastPullSyncedAtTimestampUseCaseImpl
 import cz.adamec.timotej.snag.lib.sync.fe.app.impl.internal.SyncEngine
 import org.koin.core.module.dsl.factoryOf
@@ -43,6 +45,7 @@ val syncAppModule =
         } binds arrayOf(EnqueueSyncOperationUseCase::class, SyncCoordinator::class)
         singleOf(::EnqueueSyncSaveUseCaseImpl) bind EnqueueSyncSaveUseCase::class
         singleOf(::EnqueueSyncDeleteUseCaseImpl) bind EnqueueSyncDeleteUseCase::class
+        singleOf(::PullSyncTrackerImpl) bind PullSyncTracker::class
         singleOf(::GetSyncStatusUseCaseImpl) bind GetSyncStatusUseCase::class
         factoryOf(::GetLastPullSyncedAtTimestampUseCaseImpl) bind GetLastPullSyncedAtTimestampUseCase::class
         factoryOf(::SetLastPullSyncedAtTimestampUseCaseImpl) bind SetLastPullSyncedAtTimestampUseCase::class

--- a/lib/sync/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/sync/fe/app/impl/internal/GetSyncStatusUseCaseImpl.kt
+++ b/lib/sync/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/sync/fe/app/impl/internal/GetSyncStatusUseCaseImpl.kt
@@ -13,6 +13,7 @@
 package cz.adamec.timotej.snag.lib.sync.fe.app.impl.internal
 
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.GetSyncStatusUseCase
+import cz.adamec.timotej.snag.lib.sync.fe.app.api.PullSyncTracker
 import cz.adamec.timotej.snag.lib.sync.fe.model.SyncStatus
 import cz.adamec.timotej.snag.network.fe.InternetConnectionStatusListener
 import kotlinx.coroutines.flow.Flow
@@ -21,15 +22,18 @@ import kotlinx.coroutines.flow.combine
 internal class GetSyncStatusUseCaseImpl(
     private val syncEngine: SyncEngine,
     private val connectionStatusListener: InternetConnectionStatusListener,
+    private val pullSyncTracker: PullSyncTracker,
 ) : GetSyncStatusUseCase {
     override fun invoke(): Flow<SyncStatus> =
         combine(
             syncEngine.status,
             connectionStatusListener.isConnectedFlow(),
-        ) { engineStatus, isConnected ->
+            pullSyncTracker.isPulling,
+        ) { engineStatus, isConnected, isPulling ->
             when {
                 !isConnected -> SyncStatus.Offline
                 engineStatus is SyncEngineStatus.Syncing -> SyncStatus.Syncing
+                isPulling -> SyncStatus.Syncing
                 engineStatus is SyncEngineStatus.Failed -> SyncStatus.Error
                 else -> SyncStatus.Synced
             }

--- a/lib/sync/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/sync/fe/app/impl/internal/PullSyncTrackerImpl.kt
+++ b/lib/sync/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/sync/fe/app/impl/internal/PullSyncTrackerImpl.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.lib.sync.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.lib.sync.fe.app.api.PullSyncTracker
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal class PullSyncTrackerImpl : PullSyncTracker {
+    private val mutex = Mutex()
+    private var activeCount = 0
+    private val _isPulling = MutableStateFlow(false)
+    override val isPulling: StateFlow<Boolean> = _isPulling
+
+    override suspend fun <T> track(block: suspend () -> T): T {
+        mutex.withLock {
+            activeCount++
+            _isPulling.value = true
+        }
+        try {
+            return block()
+        } finally {
+            mutex.withLock {
+                activeCount--
+                _isPulling.value = activeCount > 0
+            }
+        }
+    }
+}

--- a/lib/sync/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/lib/sync/fe/app/impl/GetSyncStatusUseCaseImplTest.kt
+++ b/lib/sync/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/lib/sync/fe/app/impl/GetSyncStatusUseCaseImplTest.kt
@@ -17,6 +17,7 @@ import cz.adamec.timotej.snag.lib.core.common.ApplicationScope
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.handler.SyncOperationHandler
 import cz.adamec.timotej.snag.lib.sync.fe.app.api.handler.SyncOperationResult
 import cz.adamec.timotej.snag.lib.sync.fe.app.impl.internal.GetSyncStatusUseCaseImpl
+import cz.adamec.timotej.snag.lib.sync.fe.app.impl.internal.PullSyncTrackerImpl
 import cz.adamec.timotej.snag.lib.sync.fe.app.impl.internal.SyncEngine
 import cz.adamec.timotej.snag.lib.sync.fe.driven.test.FakeSyncQueue
 import cz.adamec.timotej.snag.lib.sync.fe.model.SyncOperationType
@@ -25,6 +26,7 @@ import cz.adamec.timotej.snag.network.fe.test.FakeInternetConnectionStatusListen
 import cz.adamec.timotej.snag.testinfra.fe.FrontendKoinInitializedTest
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.koin.test.inject
@@ -37,6 +39,7 @@ class GetSyncStatusUseCaseImplTest : FrontendKoinInitializedTest() {
     private val fakeSyncQueue: FakeSyncQueue by inject()
     private val applicationScope: ApplicationScope by inject()
     private val fakeConnectionListener = FakeInternetConnectionStatusListener()
+    private val pullSyncTracker = PullSyncTrackerImpl()
 
     private fun createEngine(handlers: List<SyncOperationHandler> = emptyList()) =
         SyncEngine(
@@ -49,6 +52,7 @@ class GetSyncStatusUseCaseImplTest : FrontendKoinInitializedTest() {
         GetSyncStatusUseCaseImpl(
             syncEngine = engine,
             connectionStatusListener = fakeConnectionListener,
+            pullSyncTracker = pullSyncTracker,
         )
 
     @Test
@@ -145,6 +149,52 @@ class GetSyncStatusUseCaseImplTest : FrontendKoinInitializedTest() {
             useCase().test {
                 assertEquals(SyncStatus.Offline, awaitItem())
             }
+        }
+
+    @Test
+    fun `connected and pulling yields Syncing`() =
+        runTest(testDispatcher) {
+            val engine = createEngine()
+            val useCase = createUseCase(engine)
+            fakeConnectionListener.emit(true)
+
+            val deferred = CompletableDeferred<Unit>()
+            val job =
+                launch {
+                    pullSyncTracker.track { deferred.await() }
+                }
+            advanceUntilIdle()
+
+            useCase().test {
+                assertEquals(SyncStatus.Syncing, awaitItem())
+            }
+
+            deferred.complete(Unit)
+            advanceUntilIdle()
+            job.join()
+        }
+
+    @Test
+    fun `disconnected and pulling yields Offline`() =
+        runTest(testDispatcher) {
+            val engine = createEngine()
+            val useCase = createUseCase(engine)
+            fakeConnectionListener.emit(false)
+
+            val deferred = CompletableDeferred<Unit>()
+            val job =
+                launch {
+                    pullSyncTracker.track { deferred.await() }
+                }
+            advanceUntilIdle()
+
+            useCase().test {
+                assertEquals(SyncStatus.Offline, awaitItem())
+            }
+
+            deferred.complete(Unit)
+            advanceUntilIdle()
+            job.join()
         }
 
     private class FixedResultHandler(

--- a/lib/sync/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/lib/sync/fe/app/impl/PullSyncTrackerImplTest.kt
+++ b/lib/sync/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/lib/sync/fe/app/impl/PullSyncTrackerImplTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.lib.sync.fe.app.impl
+
+import cz.adamec.timotej.snag.lib.sync.fe.app.impl.internal.PullSyncTrackerImpl
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PullSyncTrackerImplTest {
+    @Test
+    fun `isPulling starts false`() {
+        val tracker = PullSyncTrackerImpl()
+        assertFalse(tracker.isPulling.value)
+    }
+
+    @Test
+    fun `isPulling is true during track and false after`() =
+        runTest {
+            val tracker = PullSyncTrackerImpl()
+            val deferred = CompletableDeferred<Unit>()
+
+            val job =
+                launch {
+                    tracker.track { deferred.await() }
+                }
+            advanceUntilIdle()
+            assertTrue(tracker.isPulling.value)
+
+            deferred.complete(Unit)
+            advanceUntilIdle()
+            assertFalse(tracker.isPulling.value)
+            job.join()
+        }
+
+    @Test
+    fun `concurrent tracks - stays true until all complete`() =
+        runTest {
+            val tracker = PullSyncTrackerImpl()
+            val deferred1 = CompletableDeferred<Unit>()
+            val deferred2 = CompletableDeferred<Unit>()
+
+            val job1 =
+                launch {
+                    tracker.track { deferred1.await() }
+                }
+            val job2 =
+                launch {
+                    tracker.track { deferred2.await() }
+                }
+            advanceUntilIdle()
+            assertTrue(tracker.isPulling.value)
+
+            deferred1.complete(Unit)
+            advanceUntilIdle()
+            assertTrue(tracker.isPulling.value)
+
+            deferred2.complete(Unit)
+            advanceUntilIdle()
+            assertFalse(tracker.isPulling.value)
+            job1.join()
+            job2.join()
+        }
+
+    @Test
+    fun `exception in track still decrements`() =
+        runTest {
+            val tracker = PullSyncTrackerImpl()
+
+            try {
+                tracker.track { throw IllegalStateException("test") }
+            } catch (_: IllegalStateException) {
+                // expected
+            }
+            assertFalse(tracker.isPulling.value)
+        }
+
+    @Test
+    fun `track returns block result`() =
+        runTest {
+            val tracker = PullSyncTrackerImpl()
+            val result = tracker.track { 42 }
+            assertEquals(42, result)
+        }
+}


### PR DESCRIPTION
## Problem Statement

The `SyncStatusBar` only reflected **push sync** (CUD operations via `SyncEngine`). **Pull sync** — fetching remote data via `PullXxxChangesUseCase` — ran invisibly in the background, leaving the status bar showing "Synced" while network requests were in flight. Additionally, per-screen loading indicators tracked local DB loading which was near-instant and never meaningfully showed.

## Solution

**Part 1 — PullSyncTracker:** Created a `PullSyncTracker` interface with `isPulling: StateFlow<Boolean>` and a `track()` method that wraps pull operations. `GetSyncStatusUseCaseImpl` now combines 3 flows (engine status, connectivity, isPulling) so the status bar shows "Syncing" during pull sync. All 6 `PullXxxChangesUseCaseImpl` classes wrap their `invoke()` body in `pullSyncTracker.track { }`.

**Part 2 — Removed per-screen loading states:** Removed `isLoading` from `ProjectsUiState`/`ClientsUiState`, removed `LOADING` from `FindingsListUiStatus`/`StructuresUiStatus`/`InspectionsUiStatus`, and removed spinner UI blocks from `ProjectDetailsContent`, `FindingDetailContent`, `StructureFloorPlanContent`, `FindingsListContent`, `ProjectsContent`, and `ClientsContent`. States that gate computed properties (`ProjectDetailsUiStatus.LOADING`, `FindingDetailUiStatus.LOADING`, `StructureDetailsUiStatus.LOADING`) were kept but their spinner branches removed.

## Test Coverage

- [x] `PullSyncTrackerImplTest`: 5 tests — starts false, true during track, false after, concurrent tracks, exception safety, returns result
- [x] `GetSyncStatusUseCaseImplTest`: 2 new tests — connected+pulling yields Syncing, disconnected+pulling yields Offline
- [x] Existing tests pass unchanged
- [x] `./gradlew check` passes

## References

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)