### PR TITLE
Redesign Users screen with M3 ListItem

### DIFF
--- a/feat/users/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/users/fe/driving/impl/internal/userManagement/ui/UserManagementContent.kt
+++ b/feat/users/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/users/fe/driving/impl/internal/userManagement/ui/UserManagementContent.kt
@@ -14,11 +14,8 @@ package cz.adamec.timotej.snag.users.fe.driving.impl.internal.userManagement.ui
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -26,15 +23,13 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.LoadingIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import cz.adamec.timotej.snag.lib.design.fe.scaffold.CollapsableTopAppBarScaffold
 import cz.adamec.timotej.snag.users.business.UserRole
-import cz.adamec.timotej.snag.users.fe.driving.impl.internal.userManagement.ui.components.RoleDropdown
+import cz.adamec.timotej.snag.users.fe.driving.impl.internal.userManagement.ui.components.UserListItem
 import cz.adamec.timotej.snag.users.fe.driving.impl.internal.userManagement.vm.UserManagementUiState
 import org.jetbrains.compose.resources.stringResource
 import snag.feat.users.fe.driving.impl.generated.resources.Res
@@ -57,41 +52,23 @@ internal fun UserManagementContent(
                     .consumeWindowInsets(paddingValues),
             contentPadding =
                 PaddingValues(
-                    start = 16.dp,
-                    end = 16.dp,
+                    start = 8.dp,
+                    end = 8.dp,
                     top = 8.dp,
                     bottom = 48.dp,
                 ),
-            verticalArrangement = Arrangement.spacedBy(0.dp),
         ) {
             items(
                 items = state.users,
                 key = { it.id },
             ) { userItem ->
-                Column {
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 12.dp),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = userItem.email,
-                            style = MaterialTheme.typography.bodyLarge,
-                            modifier = Modifier.weight(1f),
-                        )
-                        RoleDropdown(
-                            selectedRole = userItem.role,
-                            onRoleSelect = { newRole ->
-                                onRoleChange(userItem.id, newRole)
-                            },
-                            enabled = !userItem.isUpdatingRole,
-                        )
-                    }
-                    HorizontalDivider()
-                }
+                UserListItem(
+                    userItem = userItem,
+                    onRoleSelect = { newRole ->
+                        onRoleChange(userItem.id, newRole)
+                    },
+                )
+                HorizontalDivider()
             }
             item {
                 AnimatedVisibility(

--- a/feat/users/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/users/fe/driving/impl/internal/userManagement/ui/components/UserListItem.kt
+++ b/feat/users/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/users/fe/driving/impl/internal/userManagement/ui/components/UserListItem.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.users.fe.driving.impl.internal.userManagement.ui.components
+
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import cz.adamec.timotej.snag.users.business.UserRole
+import cz.adamec.timotej.snag.users.fe.driving.impl.internal.userManagement.ui.toDisplayName
+import cz.adamec.timotej.snag.users.fe.driving.impl.internal.userManagement.vm.UserItem
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import snag.feat.users.fe.driving.impl.generated.resources.Res
+import snag.feat.users.fe.driving.impl.generated.resources.no_role
+import snag.lib.design.fe.generated.resources.ic_person
+import snag.lib.design.fe.generated.resources.Res as DesignRes
+
+@Composable
+internal fun UserListItem(
+    userItem: UserItem,
+    onRoleSelect: (UserRole?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ListItem(
+        modifier = modifier,
+        leadingContent = {
+            Icon(
+                painter = painterResource(DesignRes.drawable.ic_person),
+                contentDescription = null,
+            )
+        },
+        headlineContent = {
+            Text(
+                text = userItem.email,
+                style = MaterialTheme.typography.titleLargeEmphasized,
+            )
+        },
+        supportingContent = {
+            Text(
+                text = userItem.role?.toDisplayName() ?: stringResource(Res.string.no_role),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+        },
+        trailingContent = {
+            RoleDropdown(
+                selectedRole = userItem.role,
+                onRoleSelect = onRoleSelect,
+                enabled = !userItem.isUpdatingRole,
+            )
+        },
+    )
+}


### PR DESCRIPTION
## Problem Statement

The Users screen used a custom `Row`-based layout for each user item (email text + role dropdown), inconsistent with how `ClientListItem` and `ProjectListItem` are implemented using the M3 `ListItem` composable.

## Solution

- Created a dedicated `UserListItem` composable following the established pattern:
  - **Leading**: Person icon (`ic_person`)
  - **Headline**: User email (`titleLargeEmphasized`)
  - **Supporting**: Role display name or "None"
  - **Trailing**: `RoleDropdown` for inline editing
- Simplified `UserManagementContent` by replacing the inline `Column > Row > Text + RoleDropdown` block with `UserListItem`
- Adjusted `contentPadding` to `8.dp` horizontal (matching `ClientsContent`)

## Test Coverage

- Existing `UserManagementContent` tests pass — no ViewModel/UiState changes
- `:feat:users:fe:driving:impl:check` passes

## References

- M3 List guidelines: https://m3.material.io/components/lists/overview
- Follows `ClientListItem` / `ProjectListItem` patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)