### PR TITLE
Fix Navigation3 Dialog crash by rendering dialogs inline

### DIFF
--- a/feat/projects/fe/driving/api/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/api/ProjectsNavigation.kt
+++ b/feat/projects/fe/driving/api/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/api/ProjectsNavigation.kt
@@ -17,9 +17,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
-import androidx.navigation3.scene.DialogSceneStrategy
 import androidx.navigation3.ui.NavDisplay
 import cz.adamec.timotej.snag.lib.design.fe.scenes.ContentPaneSceneStrategy
+import cz.adamec.timotej.snag.lib.design.fe.scenes.InlineDialogSceneStrategy
 import org.koin.compose.koinInject
 import org.koin.compose.navigation3.koinEntryProvider
 
@@ -34,8 +34,9 @@ fun ProjectsNavigation(
     val entryProvider = koinEntryProvider<ProjectsNavRoute>()
     val sceneStrategy =
         remember {
-            DialogSceneStrategy<ProjectsNavRoute>() then
-                ContentPaneSceneStrategy()
+            InlineDialogSceneStrategy<ProjectsNavRoute>(
+                backgroundStrategy = ContentPaneSceneStrategy(),
+            )
         }
     NavDisplay(
         modifier = modifier,

--- a/feat/users/fe/driving/api/src/commonMain/kotlin/cz/adamec/timotej/snag/users/fe/driving/api/UsersNavigation.kt
+++ b/feat/users/fe/driving/api/src/commonMain/kotlin/cz/adamec/timotej/snag/users/fe/driving/api/UsersNavigation.kt
@@ -17,9 +17,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
-import androidx.navigation3.scene.DialogSceneStrategy
 import androidx.navigation3.ui.NavDisplay
 import cz.adamec.timotej.snag.lib.design.fe.scenes.ContentPaneSceneStrategy
+import cz.adamec.timotej.snag.lib.design.fe.scenes.InlineDialogSceneStrategy
 import org.koin.compose.koinInject
 import org.koin.compose.navigation3.koinEntryProvider
 
@@ -31,8 +31,9 @@ fun UsersNavigation(
     val entryProvider = koinEntryProvider<UsersNavRoute>()
     val sceneStrategy =
         remember {
-            DialogSceneStrategy<UsersNavRoute>() then
-                ContentPaneSceneStrategy()
+            InlineDialogSceneStrategy<UsersNavRoute>(
+                backgroundStrategy = ContentPaneSceneStrategy(),
+            )
         }
     NavDisplay(
         modifier = modifier,

--- a/lib/design/fe/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/design/fe/scenes/InlineDialogSceneStrategy.kt
+++ b/lib/design/fe/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/design/fe/scenes/InlineDialogSceneStrategy.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.lib.design.fe.scenes
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.scene.Scene
+import androidx.navigation3.scene.SceneStrategy
+import androidx.navigation3.scene.SceneStrategyScope
+
+/**
+ * Renders dialog entries as inline composable overlays (stacked in a [Box])
+ * instead of platform `Dialog` windows.
+ *
+ * This avoids the cross-composition-tree `movableContentOf` crash that
+ * [androidx.navigation3.scene.DialogSceneStrategy] triggers when
+ * scene state is recalculated with unstable `NavEntry` references.
+ */
+class InlineDialogSceneStrategy<T : Any>(
+    private val backgroundStrategy: SceneStrategy<T>,
+) : SceneStrategy<T> {
+    override fun SceneStrategyScope<T>.calculateScene(entries: List<NavEntry<T>>): Scene<T>? {
+        val dialogIndex =
+            entries.indexOfLast { it.metadata.containsKey(DIALOG_KEY) }
+
+        if (dialogIndex < 0) {
+            return with(backgroundStrategy) { calculateScene(entries) }
+        }
+
+        val backgroundEntries = entries.subList(fromIndex = 0, toIndex = dialogIndex)
+        val dialogEntry = entries[dialogIndex]
+        val backgroundScene =
+            if (backgroundEntries.isNotEmpty()) {
+                with(backgroundStrategy) { calculateScene(backgroundEntries) }
+            } else {
+                null
+            }
+
+        return InlineDialogScene(
+            key = dialogEntry.contentKey,
+            entries = entries,
+            backgroundScene = backgroundScene,
+            dialogEntry = dialogEntry,
+        )
+    }
+
+    companion object {
+        /**
+         * Matches the key used by [androidx.navigation3.scene.DialogSceneStrategy.dialog].
+         */
+        private const val DIALOG_KEY = "dialog"
+    }
+}
+
+private class InlineDialogScene<T : Any>(
+    override val key: Any,
+    override val entries: List<NavEntry<T>>,
+    private val backgroundScene: Scene<T>?,
+    private val dialogEntry: NavEntry<T>,
+) : Scene<T> {
+    override val previousEntries: List<NavEntry<T>> = emptyList()
+
+    override val content: @Composable () -> Unit = {
+        Box(modifier = Modifier.fillMaxSize()) {
+            backgroundScene?.content?.invoke()
+            dialogEntry.Content()
+        }
+    }
+}


### PR DESCRIPTION
## Problem Statement

Navigation3's `DialogSceneStrategy` creates platform `Dialog` windows with separate composition trees. When `SceneSetupNavEntryDecorator` uses `movableContentOf` and the scene state is recalculated (due to unstable `NavEntry` references), both old and new `DialogScene`s try to render via the same `movableContentOf` key — moving `LayoutNode`s across separate composition trees, which is illegal and crashes. This affects **all** dialog-based navigation (clients, projects, structures, findings, inspections).

## Solution

Replace `DialogSceneStrategy` with a custom `InlineDialogSceneStrategy` that renders dialog entries as inline composable overlays (`Box` in the same composition tree) instead of platform `Dialog` windows. This avoids the cross-tree `movableContentOf` conflict entirely.

Key design decisions:
- **No `OverlayScene`**: The returned scene is a plain `Scene`, not `OverlayScene`, keeping everything in one composition tree
- **Constructor injection of background strategy**: Replaces the `then` combinator chain
- **Reuse `DialogSceneStrategy.DIALOG_KEY`**: Feature modules keep tagging entries with `DialogSceneStrategy.dialog(...)` metadata — no changes needed in DrivingModule files

## Test Coverage

- [ ] Navigate to Clients → "New Client" → verify dialog opens without crash
- [ ] Fill form and save → verify dialog closes and client is created
- [ ] Test "Edit Client" dialog
- [ ] Test project creation/edit dialogs
- [ ] Test structure creation/edit dialogs
- [ ] Test finding creation/edit dialogs
- [ ] Test inspection creation/edit dialogs

## References

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)