### PR TITLE
Add missing tests for clients module use cases

### DIFF
--- a/feat/clients/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/clients/be/app/impl/internal/DeleteClientUseCaseImplTest.kt
+++ b/feat/clients/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/clients/be/app/impl/internal/DeleteClientUseCaseImplTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.clients.be.app.impl.internal
+
+import cz.adamec.timotej.snag.clients.be.app.api.DeleteClientUseCase
+import cz.adamec.timotej.snag.clients.be.app.api.model.DeleteClientRequest
+import cz.adamec.timotej.snag.clients.be.model.BackendClientData
+import cz.adamec.timotej.snag.clients.be.ports.ClientsDb
+import cz.adamec.timotej.snag.core.foundation.common.Timestamp
+import cz.adamec.timotej.snag.testinfra.be.BackendKoinInitializedTest
+import kotlinx.coroutines.test.runTest
+import org.koin.test.inject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.uuid.Uuid
+
+class DeleteClientUseCaseImplTest : BackendKoinInitializedTest() {
+    private val dataSource: ClientsDb by inject()
+    private val useCase: DeleteClientUseCase by inject()
+
+    private val clientId = Uuid.parse("00000000-0000-0000-0000-000000000001")
+
+    private val client =
+        BackendClientData(
+            id = clientId,
+            name = "Test Client",
+            address = "Test Address",
+            phoneNumber = "+420123456789",
+            email = "test@example.com",
+            updatedAt = Timestamp(10L),
+        )
+
+    @Test
+    fun `soft-deletes client in storage`() =
+        runTest(testDispatcher) {
+            dataSource.saveClient(client)
+
+            useCase(DeleteClientRequest(clientId = clientId, deletedAt = Timestamp(20L)))
+
+            val deletedClient = dataSource.getClient(clientId)
+            assertNotNull(deletedClient)
+            assertEquals(Timestamp(20L), deletedClient.deletedAt)
+        }
+
+    @Test
+    fun `does not delete client when saved updated at is later than deleted at`() =
+        runTest(testDispatcher) {
+            dataSource.saveClient(client)
+
+            useCase(
+                DeleteClientRequest(
+                    clientId = clientId,
+                    deletedAt = Timestamp(value = 1L),
+                ),
+            )
+
+            assertNotNull(dataSource.getClient(clientId))
+        }
+
+    @Test
+    fun `returns saved client when saved updated at is later than deleted at`() =
+        runTest(testDispatcher) {
+            dataSource.saveClient(client)
+
+            val result =
+                useCase(
+                    DeleteClientRequest(
+                        clientId = clientId,
+                        deletedAt = Timestamp(value = 1L),
+                    ),
+                )
+
+            assertNotNull(result)
+            assertEquals(client, result)
+        }
+
+    @Test
+    fun `returns null if no client was saved`() =
+        runTest(testDispatcher) {
+            val result =
+                useCase(
+                    DeleteClientRequest(
+                        clientId = clientId,
+                        deletedAt = Timestamp(value = 20L),
+                    ),
+                )
+
+            assertNull(result)
+        }
+}

--- a/feat/clients/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/clients/be/app/impl/internal/GetClientUseCaseImplTest.kt
+++ b/feat/clients/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/clients/be/app/impl/internal/GetClientUseCaseImplTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.clients.be.app.impl.internal
+
+import cz.adamec.timotej.snag.clients.be.app.api.GetClientUseCase
+import cz.adamec.timotej.snag.clients.be.model.BackendClientData
+import cz.adamec.timotej.snag.clients.be.ports.ClientsDb
+import cz.adamec.timotej.snag.core.foundation.common.Timestamp
+import cz.adamec.timotej.snag.testinfra.be.BackendKoinInitializedTest
+import kotlinx.coroutines.test.runTest
+import org.koin.test.inject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.uuid.Uuid
+
+class GetClientUseCaseImplTest : BackendKoinInitializedTest() {
+    private val dataSource: ClientsDb by inject()
+    private val useCase: GetClientUseCase by inject()
+
+    private val clientId = Uuid.parse("00000000-0000-0000-0000-000000000001")
+
+    private val client =
+        BackendClientData(
+            id = clientId,
+            name = "Test Client",
+            address = "Test Address",
+            phoneNumber = "+420123456789",
+            email = "test@example.com",
+            updatedAt = Timestamp(10L),
+        )
+
+    @Test
+    fun `returns client when it exists`() =
+        runTest(testDispatcher) {
+            dataSource.saveClient(client)
+
+            val result = useCase(clientId)
+
+            assertEquals(client, result)
+        }
+
+    @Test
+    fun `returns null when not found`() =
+        runTest(testDispatcher) {
+            val result = useCase(clientId)
+
+            assertNull(result)
+        }
+}

--- a/feat/clients/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/clients/be/app/impl/internal/GetClientsModifiedSinceUseCaseImplTest.kt
+++ b/feat/clients/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/clients/be/app/impl/internal/GetClientsModifiedSinceUseCaseImplTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.clients.be.app.impl.internal
+
+import cz.adamec.timotej.snag.clients.be.app.api.GetClientsModifiedSinceUseCase
+import cz.adamec.timotej.snag.clients.be.model.BackendClientData
+import cz.adamec.timotej.snag.clients.be.ports.ClientsDb
+import cz.adamec.timotej.snag.core.foundation.common.Timestamp
+import cz.adamec.timotej.snag.testinfra.be.BackendKoinInitializedTest
+import kotlinx.coroutines.test.runTest
+import org.koin.test.inject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+class GetClientsModifiedSinceUseCaseImplTest : BackendKoinInitializedTest() {
+    private val dataSource: ClientsDb by inject()
+    private val useCase: GetClientsModifiedSinceUseCase by inject()
+
+    @Test
+    fun `returns empty list when no clients exist`() =
+        runTest(testDispatcher) {
+            val result = useCase(since = Timestamp(100L))
+
+            assertTrue(result.isEmpty())
+        }
+
+    @Test
+    fun `returns clients with updatedAt after since`() =
+        runTest(testDispatcher) {
+            val client =
+                BackendClientData(
+                    id = Uuid.parse("00000000-0000-0000-0000-000000000001"),
+                    name = "Client 1",
+                    address = "Address 1",
+                    phoneNumber = null,
+                    email = null,
+                    updatedAt = Timestamp(200L),
+                )
+            dataSource.saveClient(client)
+
+            val result = useCase(since = Timestamp(100L))
+
+            assertEquals(listOf(client), result)
+        }
+
+    @Test
+    fun `excludes clients with updatedAt before since`() =
+        runTest(testDispatcher) {
+            val client =
+                BackendClientData(
+                    id = Uuid.parse("00000000-0000-0000-0000-000000000001"),
+                    name = "Client 1",
+                    address = "Address 1",
+                    phoneNumber = null,
+                    email = null,
+                    updatedAt = Timestamp(50L),
+                )
+            dataSource.saveClient(client)
+
+            val result = useCase(since = Timestamp(100L))
+
+            assertTrue(result.isEmpty())
+        }
+
+    @Test
+    fun `returns deleted clients when deletedAt is after since`() =
+        runTest(testDispatcher) {
+            val client =
+                BackendClientData(
+                    id = Uuid.parse("00000000-0000-0000-0000-000000000001"),
+                    name = "Client 1",
+                    address = "Address 1",
+                    phoneNumber = null,
+                    email = null,
+                    updatedAt = Timestamp(50L),
+                    deletedAt = Timestamp(200L),
+                )
+            dataSource.saveClient(client)
+
+            val result = useCase(since = Timestamp(100L))
+
+            assertEquals(listOf(client), result)
+        }
+
+    @Test
+    fun `excludes deleted clients when deletedAt is before since`() =
+        runTest(testDispatcher) {
+            val client =
+                BackendClientData(
+                    id = Uuid.parse("00000000-0000-0000-0000-000000000001"),
+                    name = "Client 1",
+                    address = "Address 1",
+                    phoneNumber = null,
+                    email = null,
+                    updatedAt = Timestamp(50L),
+                    deletedAt = Timestamp(80L),
+                )
+            dataSource.saveClient(client)
+
+            val result = useCase(since = Timestamp(100L))
+
+            assertTrue(result.isEmpty())
+        }
+}

--- a/feat/clients/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/clients/be/app/impl/internal/GetClientsUseCaseImplTest.kt
+++ b/feat/clients/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/clients/be/app/impl/internal/GetClientsUseCaseImplTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.clients.be.app.impl.internal
+
+import cz.adamec.timotej.snag.clients.be.app.api.GetClientsUseCase
+import cz.adamec.timotej.snag.clients.be.model.BackendClientData
+import cz.adamec.timotej.snag.clients.be.ports.ClientsDb
+import cz.adamec.timotej.snag.core.foundation.common.Timestamp
+import cz.adamec.timotej.snag.testinfra.be.BackendKoinInitializedTest
+import kotlinx.coroutines.test.runTest
+import org.koin.test.inject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+class GetClientsUseCaseImplTest : BackendKoinInitializedTest() {
+    private val dataSource: ClientsDb by inject()
+    private val useCase: GetClientsUseCase by inject()
+
+    @Test
+    fun `returns empty list when none exist`() =
+        runTest(testDispatcher) {
+            val result = useCase()
+
+            assertEquals(emptyList(), result)
+        }
+
+    @Test
+    fun `returns all clients`() =
+        runTest(testDispatcher) {
+            val client1 =
+                BackendClientData(
+                    id = Uuid.parse("00000000-0000-0000-0000-000000000001"),
+                    name = "Client 1",
+                    address = "Address 1",
+                    phoneNumber = null,
+                    email = null,
+                    updatedAt = Timestamp(10L),
+                )
+            val client2 =
+                BackendClientData(
+                    id = Uuid.parse("00000000-0000-0000-0000-000000000002"),
+                    name = "Client 2",
+                    address = "Address 2",
+                    phoneNumber = null,
+                    email = null,
+                    updatedAt = Timestamp(10L),
+                )
+            dataSource.saveClient(client1)
+            dataSource.saveClient(client2)
+
+            val result = useCase()
+
+            assertEquals(listOf(client1, client2), result)
+        }
+}

--- a/feat/clients/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/clients/be/app/impl/internal/SaveClientUseCaseImplTest.kt
+++ b/feat/clients/be/app/impl/src/test/kotlin/cz/adamec/timotej/snag/clients/be/app/impl/internal/SaveClientUseCaseImplTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.clients.be.app.impl.internal
+
+import cz.adamec.timotej.snag.clients.be.app.api.SaveClientUseCase
+import cz.adamec.timotej.snag.clients.be.model.BackendClientData
+import cz.adamec.timotej.snag.clients.be.ports.ClientsDb
+import cz.adamec.timotej.snag.core.foundation.common.Timestamp
+import cz.adamec.timotej.snag.testinfra.be.BackendKoinInitializedTest
+import kotlinx.coroutines.test.runTest
+import org.koin.test.inject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.uuid.Uuid
+
+class SaveClientUseCaseImplTest : BackendKoinInitializedTest() {
+    private val dataSource: ClientsDb by inject()
+    private val useCase: SaveClientUseCase by inject()
+
+    private val clientId = Uuid.parse("00000000-0000-0000-0000-000000000001")
+
+    private val client =
+        BackendClientData(
+            id = clientId,
+            name = "Test Client",
+            address = "Test Address",
+            phoneNumber = "+420123456789",
+            email = "test@example.com",
+            updatedAt = Timestamp(10L),
+        )
+
+    @Test
+    fun `saves client to data source`() =
+        runTest(testDispatcher) {
+            useCase(client)
+
+            val stored = dataSource.getClient(clientId)
+            assertEquals(client, stored)
+        }
+
+    @Test
+    fun `does not save client if saved updated at is later than the new one`() =
+        runTest(testDispatcher) {
+            val savedClient =
+                client.copy(
+                    updatedAt = Timestamp(value = 20L),
+                )
+            dataSource.saveClient(savedClient)
+
+            useCase(client)
+
+            assertEquals(savedClient, dataSource.getClient(clientId))
+        }
+
+    @Test
+    fun `returns null if client was not present`() =
+        runTest(testDispatcher) {
+            val result = useCase(client)
+
+            assertNull(result)
+        }
+
+    @Test
+    fun `returns saved client if saved updated at is later than the new one`() =
+        runTest(testDispatcher) {
+            val savedClient =
+                client.copy(
+                    updatedAt = Timestamp(value = 20L),
+                )
+            dataSource.saveClient(savedClient)
+
+            val result = useCase(client)
+
+            assertEquals(savedClient, result)
+        }
+
+    @Test
+    fun `returns null if saved updated at is earlier than the new one`() =
+        runTest(testDispatcher) {
+            dataSource.saveClient(client)
+
+            val newerClient =
+                client.copy(
+                    name = "New name",
+                    updatedAt = Timestamp(value = 20L),
+                )
+
+            val result = useCase(newerClient)
+
+            assertNull(result)
+        }
+
+    @Test
+    fun `restores soft-deleted client when saved with newer updatedAt`() =
+        runTest(testDispatcher) {
+            val deletedClient = client.copy(deletedAt = Timestamp(15L))
+            dataSource.saveClient(deletedClient)
+
+            val restoredClient =
+                client.copy(
+                    name = "Restored",
+                    updatedAt = Timestamp(value = 20L),
+                )
+
+            val result = useCase(restoredClient)
+
+            assertNull(result)
+            val stored = dataSource.getClient(clientId)
+            assertNotNull(stored)
+            assertNull(stored.deletedAt)
+            assertEquals("Restored", stored.name)
+        }
+
+    @Test
+    fun `does not restore soft-deleted client when saved with older updatedAt`() =
+        runTest(testDispatcher) {
+            val deletedClient = client.copy(deletedAt = Timestamp(15L))
+            dataSource.saveClient(deletedClient)
+
+            val olderClient =
+                client.copy(
+                    updatedAt = Timestamp(value = 5L),
+                )
+
+            val result = useCase(olderClient)
+
+            assertNotNull(result)
+            assertEquals(deletedClient, result)
+        }
+}

--- a/feat/clients/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/clients/fe/app/impl/internal/GetClientUseCaseImplTest.kt
+++ b/feat/clients/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/clients/fe/app/impl/internal/GetClientUseCaseImplTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.clients.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.clients.app.model.AppClient
+import cz.adamec.timotej.snag.clients.app.model.AppClientData
+import cz.adamec.timotej.snag.clients.fe.app.api.GetClientUseCase
+import cz.adamec.timotej.snag.clients.fe.driven.test.FakeClientsDb
+import cz.adamec.timotej.snag.core.foundation.common.Timestamp
+import cz.adamec.timotej.snag.core.network.fe.OfflineFirstDataResult
+import cz.adamec.timotej.snag.testinfra.fe.FrontendKoinInitializedTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.koin.test.inject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.uuid.Uuid
+
+class GetClientUseCaseImplTest : FrontendKoinInitializedTest() {
+    private val fakeClientsDb: FakeClientsDb by inject()
+    private val useCase: GetClientUseCase by inject()
+
+    private val clientId = Uuid.parse("00000000-0000-0000-0000-000000000001")
+
+    @Test
+    fun `emits client from db flow`() =
+        runTest(testDispatcher) {
+            val client =
+                AppClientData(
+                    id = clientId,
+                    name = "Test Client",
+                    address = "Test Address",
+                    phoneNumber = "+420123456789",
+                    email = "test@example.com",
+                    updatedAt = Timestamp(100L),
+                )
+            fakeClientsDb.setClient(client)
+
+            val result = useCase(clientId).first()
+
+            assertIs<OfflineFirstDataResult.Success<AppClient?>>(result)
+            assertEquals(client, result.data)
+        }
+
+    @Test
+    fun `emits null when client not found`() =
+        runTest(testDispatcher) {
+            val result = useCase(clientId).first()
+
+            assertIs<OfflineFirstDataResult.Success<AppClient?>>(result)
+            assertNull(result.data)
+        }
+}

--- a/feat/clients/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/clients/fe/app/impl/internal/GetClientsUseCaseImplTest.kt
+++ b/feat/clients/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/clients/fe/app/impl/internal/GetClientsUseCaseImplTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.clients.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.clients.app.model.AppClient
+import cz.adamec.timotej.snag.clients.app.model.AppClientData
+import cz.adamec.timotej.snag.clients.fe.app.api.GetClientsUseCase
+import cz.adamec.timotej.snag.clients.fe.driven.test.FakeClientsDb
+import cz.adamec.timotej.snag.core.foundation.common.Timestamp
+import cz.adamec.timotej.snag.core.network.fe.OfflineFirstDataResult
+import cz.adamec.timotej.snag.testinfra.fe.FrontendKoinInitializedTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.koin.test.inject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.uuid.Uuid
+
+class GetClientsUseCaseImplTest : FrontendKoinInitializedTest() {
+    private val fakeClientsDb: FakeClientsDb by inject()
+    private val useCase: GetClientsUseCase by inject()
+
+    @Test
+    fun `emits clients from db flow`() =
+        runTest(testDispatcher) {
+            val client =
+                AppClientData(
+                    id = Uuid.parse("00000000-0000-0000-0000-000000000001"),
+                    name = "Test Client",
+                    address = "Test Address",
+                    phoneNumber = "+420123456789",
+                    email = "test@example.com",
+                    updatedAt = Timestamp(100L),
+                )
+            fakeClientsDb.setClient(client)
+
+            val result = useCase().first()
+
+            assertIs<OfflineFirstDataResult.Success<List<AppClient>>>(result)
+            assertEquals(1, result.data.size)
+            assertEquals(client, result.data[0])
+        }
+
+    @Test
+    fun `emits empty list when no clients`() =
+        runTest(testDispatcher) {
+            val result = useCase().first()
+
+            assertIs<OfflineFirstDataResult.Success<List<AppClient>>>(result)
+            assertEquals(emptyList(), result.data)
+        }
+}


### PR DESCRIPTION
Backend (5 new test files, 20 tests):
- SaveClientUseCaseImplTest: save, timestamp conflict, soft-delete restore
- DeleteClientUseCaseImplTest: soft-delete, timestamp conflict, missing entity
- GetClientUseCaseImplTest: exists and not-found cases
- GetClientsUseCaseImplTest: empty and populated list
- GetClientsModifiedSinceUseCaseImplTest: timestamp filtering, deleted entities

Frontend (2 new test files, 4 tests):
- GetClientUseCaseImplTest: db flow emission, not-found case
- GetClientsUseCaseImplTest: db flow emission, empty list

https://claude.ai/code/session_01DicJcj1G9pxLnXx2xkmWFJ