### PR TITLE
Rename Users to Colleagues in UI (#141)

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -13,6 +13,6 @@
 <resources>
     <string name="projects_tab_title">Projects</string>
     <string name="directory_tab_title">Directory</string>
-    <string name="users_tab_title">Users</string>
+    <string name="users_tab_title">Colleagues</string>
     <string name="clients_tab_title">Clients</string>
 </resources>

--- a/feat/users/fe/driving/impl/src/commonMain/composeResources/values/strings.xml
+++ b/feat/users/fe/driving/impl/src/commonMain/composeResources/values/strings.xml
@@ -11,7 +11,7 @@
   -->
 
 <resources>
-    <string name="users_title">Users</string>
+    <string name="users_title">Colleagues</string>
     <string name="role_label">Role</string>
     <string name="no_role">None</string>
     <string name="role_administrator">Administrator</string>


### PR DESCRIPTION
## Problem

The app refers to other people as "Users," which feels impersonal. In a construction/inspection context, "Colleagues" is more natural and team-oriented.

## Solution

Renamed two user-facing strings from "Users" to "Colleagues":
- Directory tab label (`users_tab_title`)
- Users screen header (`users_title`)

Internal code naming (`User`, resource keys, etc.) remains unchanged per issue scope.

## Test Coverage

- String resource files only — no logic changes
- Visual verification: Directory tab and user list header display "Colleagues"

## References

Closes #141