### PR TITLE
Create common SnagNavDisplay composable to reduce NavDisplay duplication

### DIFF
--- a/composeApp/src/commonMain/kotlin/cz/adamec/timotej/snag/directory/ui/DirectoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/cz/adamec/timotej/snag/directory/ui/DirectoryScreen.kt
@@ -21,20 +21,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
-import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
-import androidx.navigation3.scene.DialogSceneStrategy
-import androidx.navigation3.ui.NavDisplay
 import cz.adamec.timotej.snag.clients.fe.driving.api.ClientCreationRouteFactory
 import cz.adamec.timotej.snag.clients.fe.driving.api.ClientEditRouteFactory
 import cz.adamec.timotej.snag.clients.fe.driving.api.ClientsRoute
 import cz.adamec.timotej.snag.clients.fe.driving.api.ClientsRouteFactory
-import cz.adamec.timotej.snag.lib.navigation.fe.SnagNavRoute
+import cz.adamec.timotej.snag.lib.navigation.fe.SnagNavDisplay
 import cz.adamec.timotej.snag.users.fe.driving.api.UsersRoute
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
-import org.koin.compose.navigation3.koinEntryProvider
 import snag.composeapp.generated.resources.Res
 import snag.composeapp.generated.resources.clients_tab_title
 import snag.composeapp.generated.resources.users_tab_title
@@ -131,20 +126,9 @@ internal fun DirectoryScreen(
             )
         }
 
-        val entryProvider = koinEntryProvider<SnagNavRoute>()
-        NavDisplay(
-            modifier = modifier,
+        SnagNavDisplay(
             backStack = backStackEntriesState.value,
-            entryProvider = entryProvider,
-            sceneStrategies =
-                listOf(
-                    DialogSceneStrategy(),
-                ),
-            entryDecorators =
-                listOf(
-                    rememberSaveableStateHolderNavEntryDecorator(),
-                    rememberViewModelStoreNavEntryDecorator(),
-                ),
+            modifier = modifier,
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/cz/adamec/timotej/snag/ui/MainNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/cz/adamec/timotej/snag/ui/MainNavigation.kt
@@ -13,31 +13,18 @@
 package cz.adamec.timotej.snag.ui
 
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
-import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
-import androidx.navigation3.scene.DialogSceneStrategy
-import androidx.navigation3.ui.NavDisplay
 import cz.adamec.timotej.snag.lib.design.fe.scenes.ContentPaneSceneStrategy
-import cz.adamec.timotej.snag.lib.navigation.fe.SnagNavRoute
+import cz.adamec.timotej.snag.lib.navigation.fe.SnagNavDisplay
 import org.koin.compose.koinInject
-import org.koin.compose.navigation3.koinEntryProvider
 
 @Composable
 internal fun MainNavigation() {
     val backStack: MainBackStack = koinInject()
-    val entryProvider = koinEntryProvider<SnagNavRoute>()
-    NavDisplay(
+    SnagNavDisplay(
         backStack = backStack.value,
-        entryProvider = entryProvider,
-        sceneStrategies =
+        additionalSceneStrategies =
             listOf(
-                DialogSceneStrategy(),
                 ContentPaneSceneStrategy(),
-            ),
-        entryDecorators =
-            listOf(
-                rememberSaveableStateHolderNavEntryDecorator(),
-                rememberViewModelStoreNavEntryDecorator(),
             ),
     )
 }

--- a/feat/projects/fe/driving/api/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/api/ProjectsNavigation.kt
+++ b/feat/projects/fe/driving/api/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driving/api/ProjectsNavigation.kt
@@ -16,14 +16,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
-import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
-import androidx.navigation3.scene.DialogSceneStrategy
-import androidx.navigation3.ui.NavDisplay
 import cz.adamec.timotej.snag.lib.design.fe.scenes.ContentPaneSceneStrategy
-import cz.adamec.timotej.snag.lib.navigation.fe.SnagNavRoute
+import cz.adamec.timotej.snag.lib.navigation.fe.SnagNavDisplay
 import org.koin.compose.koinInject
-import org.koin.compose.navigation3.koinEntryProvider
 
 @Composable
 fun ProjectsNavigation(
@@ -31,19 +26,12 @@ fun ProjectsNavigation(
 ) {
     val injectedBackStack: ProjectsBackStack = koinInject()
     val backStack = remember { mutableStateOf(injectedBackStack.value) }
-    val entryProvider = koinEntryProvider<SnagNavRoute>()
-    NavDisplay(
-        modifier = modifier,
+    SnagNavDisplay(
         backStack = backStack.value,
-        entryProvider = entryProvider,
-        sceneStrategies = listOf(
-            DialogSceneStrategy(),
-            ContentPaneSceneStrategy(),
-        ),
-        entryDecorators =
+        modifier = modifier,
+        additionalSceneStrategies =
             listOf(
-                rememberSaveableStateHolderNavEntryDecorator(),
-                rememberViewModelStoreNavEntryDecorator(),
+                ContentPaneSceneStrategy(),
             ),
     )
 }

--- a/feat/structures/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/internal/structureDetails/ui/StructureDetailNestedNav.kt
+++ b/feat/structures/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/structures/fe/driving/impl/internal/structureDetails/ui/StructureDetailNestedNav.kt
@@ -18,18 +18,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
-import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
-import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
-import androidx.navigation3.scene.DialogSceneStrategy
-import androidx.navigation3.ui.NavDisplay
 import cz.adamec.timotej.snag.feat.findings.fe.driving.api.FindingsListRouteFactory
 import cz.adamec.timotej.snag.feat.structures.fe.driving.api.StructureDetailBackStack
 import cz.adamec.timotej.snag.feat.structures.fe.driving.api.StructureDetailNavRoute
 import cz.adamec.timotej.snag.feat.structures.fe.driving.api.StructureFloorPlanRouteFactory
 import cz.adamec.timotej.snag.lib.design.fe.scenes.MapListDetailSceneStrategy
-import cz.adamec.timotej.snag.lib.navigation.fe.SnagNavRoute
+import cz.adamec.timotej.snag.lib.navigation.fe.SnagNavDisplay
 import org.koin.compose.koinInject
-import org.koin.compose.navigation3.koinEntryProvider
 import kotlin.uuid.Uuid
 
 @Composable
@@ -42,7 +37,6 @@ internal fun StructureDetailNestedNav(
     val backStack = remember { mutableStateOf(injectedInnerBackStack.value) }
     val structureFloorPlanRouteFactory = koinInject<StructureFloorPlanRouteFactory>()
     val findingsListRouteFactory = koinInject<FindingsListRouteFactory>()
-    val koinEntryProvider = koinEntryProvider<SnagNavRoute>()
     val currentOnExit = rememberUpdatedState(onExit)
 
     LaunchedEffect(Unit) {
@@ -89,17 +83,11 @@ internal fun StructureDetailNestedNav(
         )
     }
 
-    NavDisplay(
+    SnagNavDisplay(
         backStack = backStack.value,
-        entryProvider = koinEntryProvider,
-        sceneStrategies = listOf(
-            DialogSceneStrategy(),
-            MapListDetailSceneStrategy(),
-        ),
-        entryDecorators =
+        additionalSceneStrategies =
             listOf(
-                rememberSaveableStateHolderNavEntryDecorator(),
-                rememberViewModelStoreNavEntryDecorator(),
+                MapListDetailSceneStrategy(),
             ),
     )
 }

--- a/lib/routing/fe/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/navigation/fe/SnagNavDisplay.kt
+++ b/lib/routing/fe/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/navigation/fe/SnagNavDisplay.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.lib.navigation.fe
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.scene.DialogSceneStrategy
+import androidx.navigation3.scene.SceneStrategy
+import androidx.navigation3.ui.NavDisplay
+import org.koin.compose.navigation3.koinEntryProvider
+
+@Composable
+fun SnagNavDisplay(
+    backStack: List<SnagNavRoute>,
+    modifier: Modifier = Modifier,
+    additionalSceneStrategies: List<SceneStrategy<SnagNavRoute>> = emptyList(),
+) {
+    NavDisplay(
+        modifier = modifier,
+        backStack = backStack,
+        entryProvider = koinEntryProvider<SnagNavRoute>(),
+        sceneStrategies =
+            listOf<SceneStrategy<SnagNavRoute>>(DialogSceneStrategy()) + additionalSceneStrategies,
+        entryDecorators =
+            listOf(
+                rememberSaveableStateHolderNavEntryDecorator(),
+                rememberViewModelStoreNavEntryDecorator(),
+            ),
+    )
+}


### PR DESCRIPTION
## Problem Statement

Every `NavDisplay` call site (4 total) duplicates the same boilerplate:
- `koinEntryProvider<SnagNavRoute>()` (all 4 sites)
- `entryDecorators` with identical decorators (all 4 sites)
- `DialogSceneStrategy()` in `sceneStrategies` (all 4 sites)

## Solution

Created a `SnagNavDisplay` composable wrapper in `lib/routing/fe` that internalizes:
- `koinEntryProvider<SnagNavRoute>()` — identical at every call site
- Both entry decorators (`rememberSaveableStateHolderNavEntryDecorator`, `rememberViewModelStoreNavEntryDecorator`)
- `DialogSceneStrategy()` — baked in since all 4 sites use it

Callers now only pass `backStack`, optional `modifier`, and optional `additionalSceneStrategies` for site-specific strategies (e.g., `ContentPaneSceneStrategy`, `MapListDetailSceneStrategy`).

## Test Coverage

- Compilation verified via `./gradlew check` — all modules compile successfully
- No new tests needed as this is a pure refactor with no behavior change

## References

Closes #142