### PR TITLE
Implement FE project assignments with full-replacement pull sync

### DIFF
--- a/feat/projects/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/api/CascadeDeleteLocalAssignmentsByProjectIdUseCase.kt
+++ b/feat/projects/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/api/CascadeDeleteLocalAssignmentsByProjectIdUseCase.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.projects.fe.app.api
+
+import kotlin.uuid.Uuid
+
+interface CascadeDeleteLocalAssignmentsByProjectIdUseCase {
+    suspend operator fun invoke(projectId: Uuid)
+}

--- a/feat/projects/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/api/CascadeRestoreLocalAssignmentsByProjectIdUseCase.kt
+++ b/feat/projects/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/api/CascadeRestoreLocalAssignmentsByProjectIdUseCase.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.projects.fe.app.api
+
+import kotlin.uuid.Uuid
+
+interface CascadeRestoreLocalAssignmentsByProjectIdUseCase {
+    suspend operator fun invoke(projectId: Uuid)
+}

--- a/feat/projects/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/api/GetProjectAssignmentsUseCase.kt
+++ b/feat/projects/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/api/GetProjectAssignmentsUseCase.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.projects.fe.app.api
+
+import cz.adamec.timotej.snag.core.network.fe.OfflineFirstDataResult
+import kotlinx.coroutines.flow.Flow
+import kotlin.uuid.Uuid
+
+interface GetProjectAssignmentsUseCase {
+    operator fun invoke(projectId: Uuid): Flow<OfflineFirstDataResult<Set<Uuid>>>
+}

--- a/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/di/ProjectsAppModule.kt
+++ b/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/di/ProjectsAppModule.kt
@@ -14,19 +14,26 @@ package cz.adamec.timotej.snag.projects.fe.app.impl.di
 
 import cz.adamec.timotej.snag.projects.business.CanEditProjectEntitiesRule
 import cz.adamec.timotej.snag.projects.fe.app.api.CanEditProjectEntitiesUseCase
+import cz.adamec.timotej.snag.projects.fe.app.api.CascadeDeleteLocalAssignmentsByProjectIdUseCase
+import cz.adamec.timotej.snag.projects.fe.app.api.CascadeRestoreLocalAssignmentsByProjectIdUseCase
 import cz.adamec.timotej.snag.projects.fe.app.api.DeleteProjectUseCase
+import cz.adamec.timotej.snag.projects.fe.app.api.GetProjectAssignmentsUseCase
 import cz.adamec.timotej.snag.projects.fe.app.api.GetProjectUseCase
 import cz.adamec.timotej.snag.projects.fe.app.api.GetProjectsUseCase
 import cz.adamec.timotej.snag.projects.fe.app.api.IsClientReferencedByProjectUseCase
 import cz.adamec.timotej.snag.projects.fe.app.api.SaveProjectUseCase
 import cz.adamec.timotej.snag.projects.fe.app.api.SetProjectClosedUseCase
 import cz.adamec.timotej.snag.projects.fe.app.impl.internal.CanEditProjectEntitiesUseCaseImpl
+import cz.adamec.timotej.snag.projects.fe.app.impl.internal.CascadeDeleteLocalAssignmentsByProjectIdUseCaseImpl
+import cz.adamec.timotej.snag.projects.fe.app.impl.internal.CascadeRestoreLocalAssignmentsByProjectIdUseCaseImpl
 import cz.adamec.timotej.snag.projects.fe.app.impl.internal.DeleteProjectUseCaseImpl
+import cz.adamec.timotej.snag.projects.fe.app.impl.internal.GetProjectAssignmentsUseCaseImpl
 import cz.adamec.timotej.snag.projects.fe.app.impl.internal.GetProjectUseCaseImpl
 import cz.adamec.timotej.snag.projects.fe.app.impl.internal.GetProjectsUseCaseImpl
 import cz.adamec.timotej.snag.projects.fe.app.impl.internal.IsClientReferencedByProjectUseCaseImpl
 import cz.adamec.timotej.snag.projects.fe.app.impl.internal.SaveProjectUseCaseImpl
 import cz.adamec.timotej.snag.projects.fe.app.impl.internal.SetProjectClosedUseCaseImpl
+import cz.adamec.timotej.snag.projects.fe.app.impl.internal.sync.ProjectAssignmentsPullSyncHandler
 import cz.adamec.timotej.snag.projects.fe.app.impl.internal.sync.ProjectPullSyncHandler
 import cz.adamec.timotej.snag.projects.fe.app.impl.internal.sync.ProjectSyncHandler
 import cz.adamec.timotej.snag.sync.fe.app.api.handler.PullSyncOperationHandler
@@ -45,6 +52,10 @@ val projectsAppModule =
         factoryOf(::CanEditProjectEntitiesUseCaseImpl) bind CanEditProjectEntitiesUseCase::class
         factoryOf(::IsClientReferencedByProjectUseCaseImpl) bind IsClientReferencedByProjectUseCase::class
         factoryOf(::CanEditProjectEntitiesRule)
+        factoryOf(::GetProjectAssignmentsUseCaseImpl) bind GetProjectAssignmentsUseCase::class
+        factoryOf(::CascadeDeleteLocalAssignmentsByProjectIdUseCaseImpl) bind CascadeDeleteLocalAssignmentsByProjectIdUseCase::class
+        factoryOf(::CascadeRestoreLocalAssignmentsByProjectIdUseCaseImpl) bind CascadeRestoreLocalAssignmentsByProjectIdUseCase::class
         factoryOf(::ProjectSyncHandler) bind PushSyncOperationHandler::class
         factoryOf(::ProjectPullSyncHandler) bind PullSyncOperationHandler::class
+        factoryOf(::ProjectAssignmentsPullSyncHandler) bind PullSyncOperationHandler::class
     }

--- a/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/CascadeDeleteLocalAssignmentsByProjectIdUseCaseImpl.kt
+++ b/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/CascadeDeleteLocalAssignmentsByProjectIdUseCaseImpl.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.projects.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.projects.fe.app.api.CascadeDeleteLocalAssignmentsByProjectIdUseCase
+import cz.adamec.timotej.snag.projects.fe.ports.ProjectAssignmentsDb
+import kotlin.uuid.Uuid
+
+internal class CascadeDeleteLocalAssignmentsByProjectIdUseCaseImpl(
+    private val projectAssignmentsDb: ProjectAssignmentsDb,
+) : CascadeDeleteLocalAssignmentsByProjectIdUseCase {
+    override suspend operator fun invoke(projectId: Uuid) {
+        projectAssignmentsDb.deleteAssignmentsByProjectId(projectId)
+    }
+}

--- a/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/CascadeRestoreLocalAssignmentsByProjectIdUseCaseImpl.kt
+++ b/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/CascadeRestoreLocalAssignmentsByProjectIdUseCaseImpl.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.projects.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.core.network.fe.OnlineDataResult
+import cz.adamec.timotej.snag.projects.fe.app.api.CascadeRestoreLocalAssignmentsByProjectIdUseCase
+import cz.adamec.timotej.snag.projects.fe.ports.ProjectAssignmentsDb
+import cz.adamec.timotej.snag.projects.fe.ports.ProjectsApi
+import kotlin.uuid.Uuid
+
+internal class CascadeRestoreLocalAssignmentsByProjectIdUseCaseImpl(
+    private val projectsApi: ProjectsApi,
+    private val projectAssignmentsDb: ProjectAssignmentsDb,
+) : CascadeRestoreLocalAssignmentsByProjectIdUseCase {
+    override suspend operator fun invoke(projectId: Uuid) {
+        when (val result = projectsApi.getProjectAssignments(projectId)) {
+            is OnlineDataResult.Success -> {
+                projectAssignmentsDb.replaceAssignments(
+                    projectId = projectId,
+                    userIds = result.data,
+                )
+            }
+            is OnlineDataResult.Failure -> {
+                LH.logger.w { "Failed to restore assignments for project $projectId." }
+            }
+        }
+    }
+}

--- a/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/DeleteProjectUseCaseImpl.kt
+++ b/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/DeleteProjectUseCaseImpl.kt
@@ -15,6 +15,7 @@ package cz.adamec.timotej.snag.projects.fe.app.impl.internal
 import cz.adamec.timotej.snag.core.network.fe.OfflineFirstDataResult
 import cz.adamec.timotej.snag.core.network.fe.log
 import cz.adamec.timotej.snag.feat.inspections.fe.app.api.CascadeDeleteLocalInspectionsByProjectIdUseCase
+import cz.adamec.timotej.snag.projects.fe.app.api.CascadeDeleteLocalAssignmentsByProjectIdUseCase
 import cz.adamec.timotej.snag.projects.fe.app.api.DeleteProjectUseCase
 import cz.adamec.timotej.snag.projects.fe.app.impl.internal.LH.logger
 import cz.adamec.timotej.snag.projects.fe.app.impl.internal.sync.PROJECT_SYNC_ENTITY_TYPE
@@ -29,10 +30,12 @@ class DeleteProjectUseCaseImpl(
     private val enqueueSyncDeleteUseCase: EnqueueSyncDeleteUseCase,
     private val cascadeDeleteLocalStructuresByProjectIdUseCase: CascadeDeleteLocalStructuresByProjectIdUseCase,
     private val cascadeDeleteLocalInspectionsByProjectIdUseCase: CascadeDeleteLocalInspectionsByProjectIdUseCase,
+    private val cascadeDeleteLocalAssignmentsByProjectIdUseCase: CascadeDeleteLocalAssignmentsByProjectIdUseCase,
 ) : DeleteProjectUseCase {
     override suspend operator fun invoke(projectId: Uuid): OfflineFirstDataResult<Unit> {
         cascadeDeleteLocalStructuresByProjectIdUseCase(projectId)
         cascadeDeleteLocalInspectionsByProjectIdUseCase(projectId)
+        cascadeDeleteLocalAssignmentsByProjectIdUseCase(projectId)
         return projectsDb
             .deleteProject(projectId)
             .also {

--- a/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/GetProjectAssignmentsUseCaseImpl.kt
+++ b/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/GetProjectAssignmentsUseCaseImpl.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.projects.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.core.foundation.common.ApplicationScope
+import cz.adamec.timotej.snag.core.network.fe.OfflineFirstDataResult
+import cz.adamec.timotej.snag.core.network.fe.log
+import cz.adamec.timotej.snag.projects.fe.app.api.GetProjectAssignmentsUseCase
+import cz.adamec.timotej.snag.projects.fe.app.impl.internal.sync.PROJECT_ASSIGNMENT_SYNC_ENTITY_TYPE
+import cz.adamec.timotej.snag.projects.fe.ports.ProjectAssignmentsDb
+import cz.adamec.timotej.snag.sync.fe.app.api.ExecutePullSyncUseCase
+import cz.adamec.timotej.snag.sync.fe.app.api.model.ExecutePullSyncRequest
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import kotlin.uuid.Uuid
+
+internal class GetProjectAssignmentsUseCaseImpl(
+    private val executePullSyncUseCase: ExecutePullSyncUseCase,
+    private val projectAssignmentsDb: ProjectAssignmentsDb,
+    private val applicationScope: ApplicationScope,
+) : GetProjectAssignmentsUseCase {
+    override operator fun invoke(projectId: Uuid): Flow<OfflineFirstDataResult<Set<Uuid>>> {
+        applicationScope.launch {
+            executePullSyncUseCase(
+                ExecutePullSyncRequest(
+                    entityTypeId = PROJECT_ASSIGNMENT_SYNC_ENTITY_TYPE,
+                    scopeId = projectId,
+                ),
+            )
+        }
+
+        return projectAssignmentsDb
+            .getAssignedUserIdsFlow(projectId)
+            .onEach {
+                LH.logger.log(
+                    offlineFirstDataResult = it,
+                    additionalInfo =
+                        "GetProjectAssignmentsUseCase, projectAssignmentsDb.getAssignedUserIdsFlow($projectId)",
+                )
+            }.distinctUntilChanged()
+    }
+}

--- a/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/sync/ProjectAssignmentSyncEntityType.kt
+++ b/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/sync/ProjectAssignmentSyncEntityType.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.projects.fe.app.impl.internal.sync
+
+internal const val PROJECT_ASSIGNMENT_SYNC_ENTITY_TYPE = "project_assignment"

--- a/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/sync/ProjectAssignmentsPullSyncHandler.kt
+++ b/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/sync/ProjectAssignmentsPullSyncHandler.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.projects.fe.app.impl.internal.sync
+
+import cz.adamec.timotej.snag.core.network.fe.OnlineDataResult
+import cz.adamec.timotej.snag.projects.fe.app.impl.internal.LH
+import cz.adamec.timotej.snag.projects.fe.ports.ProjectAssignmentsDb
+import cz.adamec.timotej.snag.projects.fe.ports.ProjectsApi
+import cz.adamec.timotej.snag.sync.fe.app.api.handler.PullSyncOperationHandler
+import cz.adamec.timotej.snag.sync.fe.app.api.handler.PullSyncOperationResult
+import kotlin.uuid.Uuid
+
+internal class ProjectAssignmentsPullSyncHandler(
+    private val projectsApi: ProjectsApi,
+    private val projectAssignmentsDb: ProjectAssignmentsDb,
+) : PullSyncOperationHandler {
+    override val entityTypeId: String = PROJECT_ASSIGNMENT_SYNC_ENTITY_TYPE
+
+    override suspend fun execute(scopeId: Uuid?): PullSyncOperationResult {
+        val projectId = requireNotNull(scopeId) { "scopeId (projectId) is required for assignment sync." }
+        LH.logger.d { "Pulling assignments for project $projectId..." }
+
+        return when (val result = projectsApi.getProjectAssignments(projectId)) {
+            is OnlineDataResult.Failure -> {
+                LH.logger.w { "Error pulling assignments for project $projectId." }
+                PullSyncOperationResult.Failure
+            }
+            is OnlineDataResult.Success -> {
+                projectAssignmentsDb.replaceAssignments(
+                    projectId = projectId,
+                    userIds = result.data,
+                )
+                LH.logger.d { "Pulled ${result.data.size} assignment(s) for project $projectId." }
+                PullSyncOperationResult.Success
+            }
+        }
+    }
+}

--- a/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/sync/ProjectPullSyncHandler.kt
+++ b/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/sync/ProjectPullSyncHandler.kt
@@ -16,6 +16,7 @@ import cz.adamec.timotej.snag.core.foundation.common.Timestamp
 import cz.adamec.timotej.snag.core.foundation.common.TimestampProvider
 import cz.adamec.timotej.snag.core.network.fe.OnlineDataResult
 import cz.adamec.timotej.snag.feat.inspections.fe.app.api.CascadeDeleteLocalInspectionsByProjectIdUseCase
+import cz.adamec.timotej.snag.projects.fe.app.api.CascadeDeleteLocalAssignmentsByProjectIdUseCase
 import cz.adamec.timotej.snag.projects.fe.app.impl.internal.LH
 import cz.adamec.timotej.snag.projects.fe.ports.ProjectSyncResult
 import cz.adamec.timotej.snag.projects.fe.ports.ProjectsApi
@@ -31,6 +32,7 @@ internal class ProjectPullSyncHandler(
     private val projectsDb: ProjectsDb,
     private val cascadeDeleteLocalStructuresByProjectIdUseCase: CascadeDeleteLocalStructuresByProjectIdUseCase,
     private val cascadeDeleteLocalInspectionsByProjectIdUseCase: CascadeDeleteLocalInspectionsByProjectIdUseCase,
+    private val cascadeDeleteLocalAssignmentsByProjectIdUseCase: CascadeDeleteLocalAssignmentsByProjectIdUseCase,
     getLastPullSyncedAtTimestampUseCase: GetLastPullSyncedAtTimestampUseCase,
     setLastPullSyncedAtTimestampUseCase: SetLastPullSyncedAtTimestampUseCase,
     timestampProvider: TimestampProvider,
@@ -54,6 +56,7 @@ internal class ProjectPullSyncHandler(
                 LH.logger.d { "Processing deleted project ${change.id}." }
                 cascadeDeleteLocalStructuresByProjectIdUseCase(change.id)
                 cascadeDeleteLocalInspectionsByProjectIdUseCase(change.id)
+                cascadeDeleteLocalAssignmentsByProjectIdUseCase(change.id)
                 projectsDb.deleteProject(change.id)
             }
             is ProjectSyncResult.Updated -> {

--- a/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/sync/ProjectSyncHandler.kt
+++ b/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/sync/ProjectSyncHandler.kt
@@ -18,6 +18,7 @@ import cz.adamec.timotej.snag.core.network.fe.OfflineFirstDataResult
 import cz.adamec.timotej.snag.core.network.fe.OnlineDataResult
 import cz.adamec.timotej.snag.feat.inspections.fe.app.api.CascadeRestoreLocalInspectionsByProjectIdUseCase
 import cz.adamec.timotej.snag.projects.app.model.AppProject
+import cz.adamec.timotej.snag.projects.fe.app.api.CascadeRestoreLocalAssignmentsByProjectIdUseCase
 import cz.adamec.timotej.snag.projects.fe.app.impl.internal.LH
 import cz.adamec.timotej.snag.projects.fe.ports.ProjectsApi
 import cz.adamec.timotej.snag.projects.fe.ports.ProjectsDb
@@ -33,6 +34,7 @@ internal class ProjectSyncHandler(
     private val projectsDb: ProjectsDb,
     private val cascadeRestoreLocalStructuresByProjectIdUseCase: CascadeRestoreLocalStructuresByProjectIdUseCase,
     private val cascadeRestoreLocalInspectionsByProjectIdUseCase: CascadeRestoreLocalInspectionsByProjectIdUseCase,
+    private val cascadeRestoreLocalAssignmentsByProjectIdUseCase: CascadeRestoreLocalAssignmentsByProjectIdUseCase,
     timestampProvider: TimestampProvider,
 ) : DbApiPushSyncHandler<AppProject>(LH.logger, timestampProvider) {
     override val entityTypeId: String = PROJECT_SYNC_ENTITY_TYPE
@@ -53,6 +55,7 @@ internal class ProjectSyncHandler(
         coroutineScope {
             launch { cascadeRestoreLocalStructuresByProjectIdUseCase(entityId) }
             launch { cascadeRestoreLocalInspectionsByProjectIdUseCase(entityId) }
+            launch { cascadeRestoreLocalAssignmentsByProjectIdUseCase(entityId) }
         }
     }
 }

--- a/feat/projects/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/CascadeDeleteLocalAssignmentsByProjectIdUseCaseImplTest.kt
+++ b/feat/projects/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/CascadeDeleteLocalAssignmentsByProjectIdUseCaseImplTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.projects.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.core.foundation.common.UuidProvider
+import cz.adamec.timotej.snag.core.network.fe.OfflineFirstDataResult
+import cz.adamec.timotej.snag.projects.fe.app.api.CascadeDeleteLocalAssignmentsByProjectIdUseCase
+import cz.adamec.timotej.snag.projects.fe.driven.test.FakeProjectAssignmentsDb
+import cz.adamec.timotej.snag.testinfra.fe.FrontendKoinInitializedTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.koin.test.inject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CascadeDeleteLocalAssignmentsByProjectIdUseCaseImplTest : FrontendKoinInitializedTest() {
+    private val fakeProjectAssignmentsDb: FakeProjectAssignmentsDb by inject()
+    private val useCase: CascadeDeleteLocalAssignmentsByProjectIdUseCase by inject()
+
+    private val projectId = UuidProvider.getUuid()
+
+    @Test
+    fun `deletes all assignments for given project`() =
+        runTest(testDispatcher) {
+            val userId1 = UuidProvider.getUuid()
+            val userId2 = UuidProvider.getUuid()
+            fakeProjectAssignmentsDb.setAssignments(projectId, setOf(userId1, userId2))
+
+            useCase(projectId)
+
+            val result = fakeProjectAssignmentsDb.getAssignedUserIdsFlow(projectId).first()
+            assertIs<OfflineFirstDataResult.Success<Set<*>>>(result)
+            assertEquals(emptySet(), result.data)
+        }
+
+    @Test
+    fun `does not affect assignments for other projects`() =
+        runTest(testDispatcher) {
+            val otherProjectId = UuidProvider.getUuid()
+            val userId = UuidProvider.getUuid()
+            fakeProjectAssignmentsDb.setAssignments(projectId, setOf(userId))
+            fakeProjectAssignmentsDb.setAssignments(otherProjectId, setOf(userId))
+
+            useCase(projectId)
+
+            val result = fakeProjectAssignmentsDb.getAssignedUserIdsFlow(otherProjectId).first()
+            assertIs<OfflineFirstDataResult.Success<Set<*>>>(result)
+            assertEquals(setOf(userId), result.data)
+        }
+}

--- a/feat/projects/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/CascadeRestoreLocalAssignmentsByProjectIdUseCaseImplTest.kt
+++ b/feat/projects/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/CascadeRestoreLocalAssignmentsByProjectIdUseCaseImplTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.projects.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.core.foundation.common.UuidProvider
+import cz.adamec.timotej.snag.core.network.fe.OfflineFirstDataResult
+import cz.adamec.timotej.snag.core.network.fe.OnlineDataResult
+import cz.adamec.timotej.snag.projects.fe.app.api.CascadeRestoreLocalAssignmentsByProjectIdUseCase
+import cz.adamec.timotej.snag.projects.fe.driven.test.FakeProjectAssignmentsDb
+import cz.adamec.timotej.snag.projects.fe.driven.test.FakeProjectsApi
+import cz.adamec.timotej.snag.testinfra.fe.FrontendKoinInitializedTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.koin.test.inject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CascadeRestoreLocalAssignmentsByProjectIdUseCaseImplTest : FrontendKoinInitializedTest() {
+    private val fakeProjectAssignmentsDb: FakeProjectAssignmentsDb by inject()
+    private val fakeProjectsApi: FakeProjectsApi by inject()
+    private val useCase: CascadeRestoreLocalAssignmentsByProjectIdUseCase by inject()
+
+    private val projectId = UuidProvider.getUuid()
+
+    @Test
+    fun `restores assignments from API`() =
+        runTest(testDispatcher) {
+            val userId1 = UuidProvider.getUuid()
+            val userId2 = UuidProvider.getUuid()
+            fakeProjectsApi.projectAssignments[projectId] = setOf(userId1, userId2)
+
+            useCase(projectId)
+
+            val result = fakeProjectAssignmentsDb.getAssignedUserIdsFlow(projectId).first()
+            assertIs<OfflineFirstDataResult.Success<Set<*>>>(result)
+            assertEquals(setOf(userId1, userId2), result.data)
+        }
+
+    @Test
+    fun `handles API failure gracefully`() =
+        runTest(testDispatcher) {
+            fakeProjectsApi.forcedFailure = OnlineDataResult.Failure.NetworkUnavailable
+
+            useCase(projectId)
+
+            val result = fakeProjectAssignmentsDb.getAssignedUserIdsFlow(projectId).first()
+            assertIs<OfflineFirstDataResult.Success<Set<*>>>(result)
+            assertEquals(emptySet(), result.data)
+        }
+}

--- a/feat/projects/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/GetProjectAssignmentsUseCaseImplTest.kt
+++ b/feat/projects/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/GetProjectAssignmentsUseCaseImplTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.projects.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.core.foundation.common.UuidProvider
+import cz.adamec.timotej.snag.core.network.fe.OfflineFirstDataResult
+import cz.adamec.timotej.snag.core.network.fe.OnlineDataResult
+import cz.adamec.timotej.snag.projects.fe.app.api.GetProjectAssignmentsUseCase
+import cz.adamec.timotej.snag.projects.fe.driven.test.FakeProjectAssignmentsDb
+import cz.adamec.timotej.snag.projects.fe.driven.test.FakeProjectsApi
+import cz.adamec.timotej.snag.testinfra.fe.FrontendKoinInitializedTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.koin.test.inject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GetProjectAssignmentsUseCaseImplTest : FrontendKoinInitializedTest() {
+    private val fakeProjectAssignmentsDb: FakeProjectAssignmentsDb by inject()
+    private val fakeProjectsApi: FakeProjectsApi by inject()
+    private val useCase: GetProjectAssignmentsUseCase by inject()
+
+    private val projectId = UuidProvider.getUuid()
+
+    @Test
+    fun `returns empty set when no assignments exist`() =
+        runTest(testDispatcher) {
+            val result = useCase(projectId).first()
+
+            assertIs<OfflineFirstDataResult.Success<Set<*>>>(result)
+            assertEquals(emptySet(), result.data)
+        }
+
+    @Test
+    fun `returns locally stored assignments`() =
+        runTest(testDispatcher) {
+            val userId1 = UuidProvider.getUuid()
+            val userId2 = UuidProvider.getUuid()
+            fakeProjectAssignmentsDb.setAssignments(projectId, setOf(userId1, userId2))
+
+            val result = useCase(projectId).first()
+
+            assertIs<OfflineFirstDataResult.Success<Set<*>>>(result)
+            assertEquals(setOf(userId1, userId2), result.data)
+        }
+
+    @Test
+    fun `does not fail when API is unavailable`() =
+        runTest(testDispatcher) {
+            fakeProjectsApi.forcedFailure = OnlineDataResult.Failure.NetworkUnavailable
+
+            val result = useCase(projectId).first()
+
+            assertIs<OfflineFirstDataResult.Success<Set<*>>>(result)
+            assertEquals(emptySet(), result.data)
+        }
+}

--- a/feat/projects/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/ProjectAssignmentsPullSyncHandlerTest.kt
+++ b/feat/projects/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/ProjectAssignmentsPullSyncHandlerTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.projects.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.core.foundation.common.UuidProvider
+import cz.adamec.timotej.snag.core.network.fe.OfflineFirstDataResult
+import cz.adamec.timotej.snag.core.network.fe.OnlineDataResult
+import cz.adamec.timotej.snag.projects.fe.app.impl.internal.sync.ProjectAssignmentsPullSyncHandler
+import cz.adamec.timotej.snag.projects.fe.driven.test.FakeProjectAssignmentsDb
+import cz.adamec.timotej.snag.projects.fe.driven.test.FakeProjectsApi
+import cz.adamec.timotej.snag.sync.fe.app.api.handler.PullSyncOperationResult
+import cz.adamec.timotej.snag.testinfra.fe.FrontendKoinInitializedTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.koin.test.inject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProjectAssignmentsPullSyncHandlerTest : FrontendKoinInitializedTest() {
+    private val fakeProjectsApi: FakeProjectsApi by inject()
+    private val fakeProjectAssignmentsDb: FakeProjectAssignmentsDb by inject()
+    private val handler: ProjectAssignmentsPullSyncHandler by inject()
+
+    private val projectId = UuidProvider.getUuid()
+
+    @Test
+    fun `fetches assignments from API and replaces in DB`() =
+        runTest(testDispatcher) {
+            val userId1 = UuidProvider.getUuid()
+            val userId2 = UuidProvider.getUuid()
+            fakeProjectsApi.projectAssignments[projectId] = setOf(userId1, userId2)
+
+            val result = handler.execute(scopeId = projectId)
+
+            assertEquals(PullSyncOperationResult.Success, result)
+            val dbResult = fakeProjectAssignmentsDb.getAssignedUserIdsFlow(projectId).first()
+            assertIs<OfflineFirstDataResult.Success<Set<*>>>(dbResult)
+            assertEquals(setOf(userId1, userId2), dbResult.data)
+        }
+
+    @Test
+    fun `returns failure when API fails`() =
+        runTest(testDispatcher) {
+            fakeProjectsApi.forcedFailure = OnlineDataResult.Failure.NetworkUnavailable
+
+            val result = handler.execute(scopeId = projectId)
+
+            assertEquals(PullSyncOperationResult.Failure, result)
+        }
+
+    @Test
+    fun `replaces existing assignments with new set`() =
+        runTest(testDispatcher) {
+            val oldUserId = UuidProvider.getUuid()
+            val newUserId = UuidProvider.getUuid()
+            fakeProjectAssignmentsDb.setAssignments(projectId, setOf(oldUserId))
+            fakeProjectsApi.projectAssignments[projectId] = setOf(newUserId)
+
+            handler.execute(scopeId = projectId)
+
+            val dbResult = fakeProjectAssignmentsDb.getAssignedUserIdsFlow(projectId).first()
+            assertIs<OfflineFirstDataResult.Success<Set<*>>>(dbResult)
+            assertEquals(setOf(newUserId), dbResult.data)
+        }
+}

--- a/feat/projects/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driven/di/ProjectsDrivenModule.kt
+++ b/feat/projects/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driven/di/ProjectsDrivenModule.kt
@@ -15,7 +15,9 @@ package cz.adamec.timotej.snag.projects.fe.driven.di
 import cz.adamec.timotej.snag.core.foundation.common.di.getIoDispatcher
 import cz.adamec.timotej.snag.projects.fe.driven.internal.api.RealProjectsApi
 import cz.adamec.timotej.snag.projects.fe.driven.internal.db.ProjectsSqlDelightDbOps
+import cz.adamec.timotej.snag.projects.fe.driven.internal.db.RealProjectAssignmentsDb
 import cz.adamec.timotej.snag.projects.fe.driven.internal.db.RealProjectsDb
+import cz.adamec.timotej.snag.projects.fe.ports.ProjectAssignmentsDb
 import cz.adamec.timotej.snag.projects.fe.ports.ProjectsApi
 import cz.adamec.timotej.snag.projects.fe.ports.ProjectsDb
 import org.koin.core.module.dsl.factoryOf
@@ -32,4 +34,10 @@ val projectsDrivenModule =
         }
         factory { RealProjectsDb(ops = get()) } bind ProjectsDb::class
         factoryOf(::RealProjectsApi) bind ProjectsApi::class
+        factory {
+            RealProjectAssignmentsDb(
+                queries = get(),
+                ioDispatcher = getIoDispatcher(),
+            )
+        } bind ProjectAssignmentsDb::class
     }

--- a/feat/projects/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driven/internal/api/RealProjectsApi.kt
+++ b/feat/projects/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driven/internal/api/RealProjectsApi.kt
@@ -92,4 +92,27 @@ internal class RealProjectsApi(
             }
         }.also { if (it is OnlineDataResult.Success) LH.logger.d { "Fetched ${it.data.size} modified projects." } }
     }
+
+    override suspend fun getProjectAssignments(projectId: Uuid): OnlineDataResult<Set<Uuid>> {
+        LH.logger.d { "Fetching assignments for project $projectId..." }
+        return safeApiCall(
+            logger = LH.logger,
+            errorContext = "Error fetching assignments for project $projectId.",
+        ) {
+            httpClient.get("/projects/$projectId/assignments")
+                .body<List<AssignedUserApiDto>>()
+                .map { Uuid.parse(it.id) }
+                .toSet()
+        }.also {
+            if (it is OnlineDataResult.Success) {
+                LH.logger.d { "Fetched ${it.data.size} assignments for project $projectId." }
+            }
+        }
+    }
 }
+
+@kotlinx.serialization.Serializable
+private data class AssignedUserApiDto(
+    val id: String,
+)
+

--- a/feat/projects/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driven/internal/db/RealProjectAssignmentsDb.kt
+++ b/feat/projects/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driven/internal/db/RealProjectAssignmentsDb.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.projects.fe.driven.internal.db
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import cz.adamec.timotej.snag.core.network.fe.OfflineFirstDataResult
+import cz.adamec.timotej.snag.feat.shared.database.fe.db.ProjectAssignmentEntityQueries
+import cz.adamec.timotej.snag.projects.fe.driven.internal.LH
+import cz.adamec.timotej.snag.projects.fe.ports.ProjectAssignmentsDb
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import kotlin.uuid.Uuid
+
+internal class RealProjectAssignmentsDb(
+    private val queries: ProjectAssignmentEntityQueries,
+    private val ioDispatcher: CoroutineDispatcher,
+) : ProjectAssignmentsDb {
+    override fun getAssignedUserIdsFlow(projectId: Uuid): Flow<OfflineFirstDataResult<Set<Uuid>>> =
+        queries
+            .selectByProjectId(projectId.toString())
+            .asFlow()
+            .mapToList(ioDispatcher)
+            .map<List<String>, OfflineFirstDataResult<Set<Uuid>>> { rows ->
+                OfflineFirstDataResult.Success(rows.map { Uuid.parse(it) }.toSet())
+            }.catch { e ->
+                LH.logger.e(e) { "Error querying project assignments for project $projectId." }
+                emit(OfflineFirstDataResult.ProgrammerError(e))
+            }
+
+    override suspend fun replaceAssignments(
+        projectId: Uuid,
+        userIds: Set<Uuid>,
+    ): OfflineFirstDataResult<Unit> =
+        try {
+            withContext(ioDispatcher) {
+                queries.transaction {
+                    queries.deleteByProjectId(projectId.toString())
+                    userIds.forEach { userId ->
+                        queries.insert(
+                            projectId = projectId.toString(),
+                            userId = userId.toString(),
+                        )
+                    }
+                }
+            }
+            OfflineFirstDataResult.Success(Unit)
+        } catch (
+            @Suppress("TooGenericExceptionCaught")
+            e: Exception,
+        ) {
+            LH.logger.e(e) { "Error replacing assignments for project $projectId." }
+            OfflineFirstDataResult.ProgrammerError(e)
+        }
+
+    override suspend fun deleteAssignmentsByProjectId(projectId: Uuid): OfflineFirstDataResult<Unit> =
+        try {
+            withContext(ioDispatcher) {
+                queries.deleteByProjectId(projectId.toString())
+            }
+            OfflineFirstDataResult.Success(Unit)
+        } catch (
+            @Suppress("TooGenericExceptionCaught")
+            e: Exception,
+        ) {
+            LH.logger.e(e) { "Error deleting assignments for project $projectId." }
+            OfflineFirstDataResult.ProgrammerError(e)
+        }
+}

--- a/feat/projects/fe/driven/test/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driven/test/FakeProjectAssignmentsDb.kt
+++ b/feat/projects/fe/driven/test/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driven/test/FakeProjectAssignmentsDb.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.projects.fe.driven.test
+
+import cz.adamec.timotej.snag.core.network.fe.OfflineFirstDataResult
+import cz.adamec.timotej.snag.projects.fe.ports.ProjectAssignmentsDb
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlin.uuid.Uuid
+
+class FakeProjectAssignmentsDb : ProjectAssignmentsDb {
+    private val assignments = MutableStateFlow<Map<Uuid, Set<Uuid>>>(emptyMap())
+
+    override fun getAssignedUserIdsFlow(projectId: Uuid): Flow<OfflineFirstDataResult<Set<Uuid>>> =
+        assignments.map { map ->
+            OfflineFirstDataResult.Success(map[projectId] ?: emptySet())
+        }
+
+    override suspend fun replaceAssignments(
+        projectId: Uuid,
+        userIds: Set<Uuid>,
+    ): OfflineFirstDataResult<Unit> {
+        assignments.value = assignments.value + (projectId to userIds)
+        return OfflineFirstDataResult.Success(Unit)
+    }
+
+    override suspend fun deleteAssignmentsByProjectId(projectId: Uuid): OfflineFirstDataResult<Unit> {
+        assignments.value = assignments.value - projectId
+        return OfflineFirstDataResult.Success(Unit)
+    }
+
+    fun setAssignments(
+        projectId: Uuid,
+        userIds: Set<Uuid>,
+    ) {
+        assignments.value = assignments.value + (projectId to userIds)
+    }
+}

--- a/feat/projects/fe/driven/test/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driven/test/FakeProjectsApi.kt
+++ b/feat/projects/fe/driven/test/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driven/test/FakeProjectsApi.kt
@@ -54,5 +54,12 @@ class FakeProjectsApi : ProjectsApi {
 
     override suspend fun getProjectsModifiedSince(since: Timestamp): OnlineDataResult<List<ProjectSyncResult>> = ops.getModifiedSinceItems()
 
+    var projectAssignments: MutableMap<Uuid, Set<Uuid>> = mutableMapOf()
+
+    override suspend fun getProjectAssignments(projectId: Uuid): OnlineDataResult<Set<Uuid>> {
+        forcedFailure?.let { return it }
+        return OnlineDataResult.Success(projectAssignments[projectId] ?: emptySet())
+    }
+
     fun setProject(project: AppProject) = ops.setItem(project)
 }

--- a/feat/projects/fe/driven/test/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driven/test/ProjectsFeDrivenTestModule.kt
+++ b/feat/projects/fe/driven/test/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/driven/test/ProjectsFeDrivenTestModule.kt
@@ -12,6 +12,7 @@
 
 package cz.adamec.timotej.snag.projects.fe.driven.test
 
+import cz.adamec.timotej.snag.projects.fe.ports.ProjectAssignmentsDb
 import cz.adamec.timotej.snag.projects.fe.ports.ProjectsApi
 import cz.adamec.timotej.snag.projects.fe.ports.ProjectsDb
 import org.koin.core.module.dsl.singleOf
@@ -22,4 +23,5 @@ val projectsFeDrivenTestModule =
     module {
         singleOf(::FakeProjectsDb) bind ProjectsDb::class
         singleOf(::FakeProjectsApi) bind ProjectsApi::class
+        singleOf(::FakeProjectAssignmentsDb) bind ProjectAssignmentsDb::class
     }

--- a/feat/projects/fe/ports/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/ports/ProjectAssignmentsDb.kt
+++ b/feat/projects/fe/ports/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/ports/ProjectAssignmentsDb.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.projects.fe.ports
+
+import cz.adamec.timotej.snag.core.network.fe.OfflineFirstDataResult
+import kotlinx.coroutines.flow.Flow
+import kotlin.uuid.Uuid
+
+interface ProjectAssignmentsDb {
+    fun getAssignedUserIdsFlow(projectId: Uuid): Flow<OfflineFirstDataResult<Set<Uuid>>>
+
+    suspend fun replaceAssignments(
+        projectId: Uuid,
+        userIds: Set<Uuid>,
+    ): OfflineFirstDataResult<Unit>
+
+    suspend fun deleteAssignmentsByProjectId(projectId: Uuid): OfflineFirstDataResult<Unit>
+}

--- a/feat/projects/fe/ports/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/ports/ProjectsApi.kt
+++ b/feat/projects/fe/ports/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/ports/ProjectsApi.kt
@@ -40,4 +40,6 @@ interface ProjectsApi {
     ): OnlineDataResult<AppProject?>
 
     suspend fun getProjectsModifiedSince(since: Timestamp): OnlineDataResult<List<ProjectSyncResult>>
+
+    suspend fun getProjectAssignments(projectId: Uuid): OnlineDataResult<Set<Uuid>>
 }

--- a/feat/shared/database/fe/api/src/commonMain/sqldelight/cz/adamec/timotej/snag/feat/shared/database/fe/db/ProjectAssignmentEntity.sq
+++ b/feat/shared/database/fe/api/src/commonMain/sqldelight/cz/adamec/timotej/snag/feat/shared/database/fe/db/ProjectAssignmentEntity.sq
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS ProjectAssignmentEntity (
+    projectId TEXT NOT NULL,
+    userId TEXT NOT NULL,
+    PRIMARY KEY (projectId, userId)
+);
+
+selectByProjectId:
+SELECT userId FROM ProjectAssignmentEntity WHERE projectId = :projectId;
+
+deleteByProjectId:
+DELETE FROM ProjectAssignmentEntity WHERE projectId = :projectId;
+
+insert:
+INSERT OR IGNORE INTO ProjectAssignmentEntity(projectId, userId) VALUES (?, ?);

--- a/feat/shared/database/fe/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/feat/shared/database/fe/impl/di/DatabaseModule.kt
+++ b/feat/shared/database/fe/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/feat/shared/database/fe/impl/di/DatabaseModule.kt
@@ -17,6 +17,7 @@ import cz.adamec.timotej.snag.feat.shared.database.fe.db.ClientEntityQueries
 import cz.adamec.timotej.snag.feat.shared.database.fe.db.FindingCoordinateEntityQueries
 import cz.adamec.timotej.snag.feat.shared.database.fe.db.FindingEntityQueries
 import cz.adamec.timotej.snag.feat.shared.database.fe.db.InspectionEntityQueries
+import cz.adamec.timotej.snag.feat.shared.database.fe.db.ProjectAssignmentEntityQueries
 import cz.adamec.timotej.snag.feat.shared.database.fe.db.ProjectEntityQueries
 import cz.adamec.timotej.snag.feat.shared.database.fe.db.SnagDatabase
 import cz.adamec.timotej.snag.feat.shared.database.fe.db.StructureEntityQueries
@@ -41,6 +42,7 @@ val databaseModule =
 
         factory { get<SnagDatabase>().clientEntityQueries } bind ClientEntityQueries::class
         factory { get<SnagDatabase>().projectEntityQueries } bind ProjectEntityQueries::class
+        factory { get<SnagDatabase>().projectAssignmentEntityQueries } bind ProjectAssignmentEntityQueries::class
         factory { get<SnagDatabase>().structureEntityQueries } bind StructureEntityQueries::class
         factory { get<SnagDatabase>().findingEntityQueries } bind FindingEntityQueries::class
         factory { get<SnagDatabase>().findingCoordinateEntityQueries } bind FindingCoordinateEntityQueries::class

--- a/implementation-guide.md
+++ b/implementation-guide.md
@@ -93,7 +93,7 @@ When a project is **closed**, only the creator retains access. Assigned users lo
 The following features are new compared to the original analysis (which had no roles):
 
 1. - [ ] **Project closure and reopening** — projects can be closed and reopened; access is determined by project state and roles. *(BE: close/reopen mechanism + `CanCloseProjectRule` + `CanAccessProjectRule` visibility filtering all done on project routes; sub-entity route authorization not yet wired)*
-2. - [ ] **User assignment to / removal from project** — leads can add/remove technicians or service workers. *(BE: API + DB + role-restricted access enforced via `CanAssignUserToProjectRule` — Admin/VP/VS allowed; TP/Ser/None denied)*
+2. - [ ] **User assignment to / removal from project** — leads can add/remove technicians or service workers. *(BE: API + DB + role-restricted access enforced via `CanAssignUserToProjectRule` — Admin/VP/VS allowed; TP/Ser/None denied. FE: local assignment cache with full-replacement pull sync, cascade delete/restore on project deletion, query use case. FE assign/unassign use cases + UI not yet implemented.)*
 3. - [ ] **Authentication (EntraID)** — mandatory Microsoft EntraID login (standalone mechanism, not a UC).
 4. - [ ] **Role management (UC7)** — admin manages all roles; passport lead delegates technician role; service lead delegates service worker role. *(BE API done: role set via PUT /users/{id}; authorization enforcement missing)*
 5. - [x] **Inspection deletion** — UC5 Scenario E. *(full-stack: BE API + DB soft delete + sync, FE use case + local delete + sync enqueue, FE UI delete button + confirmation dialog)*
@@ -108,8 +108,8 @@ The following features are new compared to the original analysis (which had no r
 |---|---|---|---|
 | FP4 | Close project — restrict access to creator, preserve data | UC1 | - [ ] Close mechanism done; creator-only close authorization enforced on BE; project visibility filtering enforced on project routes. *(sub-entity routes not yet wired)* |
 | FP4b | Reopen project — reopen a closed project | UC1 | - [ ] Reopen mechanism done; creator-only reopen authorization enforced on BE; project visibility filtering enforced on project routes. *(sub-entity routes not yet wired)* |
-| FP4c | Assign user to project | UC1 | - [x] BE API + DB + role-restricted access enforced via `CanAssignUserToProjectRule` |
-| FP4d | Remove user from project | UC1 | - [x] BE API + DB + role-restricted access enforced via `CanAssignUserToProjectRule` |
+| FP4c | Assign user to project | UC1 | - [x] BE API + DB + role-restricted access enforced via `CanAssignUserToProjectRule`. FE: local assignment cache synced from BE (full-replacement pull sync). *(FE assign/unassign use cases + UI not yet implemented)* |
+| FP4d | Remove user from project | UC1 | - [x] BE API + DB + role-restricted access enforced via `CanAssignUserToProjectRule`. FE: cascade delete on project deletion. *(FE remove use case + UI not yet implemented)* |
 | FP4e | Close project — creator access: only creator retains access to closed project | UC1 | - [ ] Sub-entity editing blocked on closed projects; `creatorId` tracked; creator-only close/reopen enforced; project visibility filtering enforced on project routes. *(sub-entity routes not yet wired)* |
 | FP10 | Delete client — only if not referenced by any project | UC2 | - [x] Done |
 | FP31 | Delete inspection | UC5 | - [x] Done |


### PR DESCRIPTION
## Problem Statement

The frontend has no concept of project assignments. The upcoming `CanEditProjectEntitiesRule` refactor (PR 2/3) will compose `CanAccessProjectRule` internally, which needs `assignedUserIds` available on the frontend. Without local assignment data, the rule can't evaluate user access on FE.

## Solution

Introduce a new synchronization pattern — **online-only writes with local read-only caching via full-replacement pull sync**. This is the first entity type in the system that doesn't use differential `?since=` sync or soft deletes. Assignments are a pure join table (`project_id, user_id`) with no timestamps.

**New components:**
- `ProjectAssignmentsDb` port + `RealProjectAssignmentsDb` (SQLDelight-backed)
- `ProjectAssignmentsPullSyncHandler` — implements `PullSyncOperationHandler` directly (not `DbApiPullSyncHandler`) with full-replacement strategy
- `GetProjectAssignmentsUseCase` — triggers background pull sync, returns local DB Flow
- `CascadeDelete/RestoreLocalAssignmentsByProjectIdUseCase` — wired into project deletion and restore chains
- `FakeProjectAssignmentsDb` + `FakeProjectsApi` extension — test doubles
- `ProjectAssignmentEntity.sq` — SQLDelight schema

**Wired into existing cascade chains:**
- `DeleteProjectUseCaseImpl` — cascade delete assignments on project delete
- `ProjectPullSyncHandler` — cascade delete on synced project deletion
- `ProjectSyncHandler` — cascade restore on rejected project deletion

## Test Coverage

- `ProjectAssignmentsPullSyncHandlerTest` — sync fetch + replace, API failure, replacement of existing data
- `GetProjectAssignmentsUseCaseImplTest` — empty set, local data, API failure resilience
- `CascadeDeleteLocalAssignmentsByProjectIdUseCaseImplTest` — delete + isolation from other projects
- `CascadeRestoreLocalAssignmentsByProjectIdUseCaseImplTest` — restore from API, API failure handling

## References

PR 1 of 3 for completing backend authorization:
1. **This PR** — FE project assignments (sync + local DB + query)
2. PR 2 — Refactor `CanEditProjectEntitiesRule` to compose `CanAccessProjectRule`
3. PR 3 — Wire BE authorization to all remaining routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)