### PR TITLE
Rename CanEditProjectEntitiesRule and compose access check on FE

### DIFF
--- a/feat/findings/be/app/impl/src/main/kotlin/cz/adamec/timotej/snag/findings/be/app/impl/internal/DeleteFindingUseCaseImpl.kt
+++ b/feat/findings/be/app/impl/src/main/kotlin/cz/adamec/timotej/snag/findings/be/app/impl/internal/DeleteFindingUseCaseImpl.kt
@@ -18,14 +18,14 @@ import cz.adamec.timotej.snag.findings.be.app.api.model.DeleteFindingRequest
 import cz.adamec.timotej.snag.findings.be.app.impl.internal.LH.logger
 import cz.adamec.timotej.snag.findings.be.ports.FindingsDb
 import cz.adamec.timotej.snag.projects.be.app.api.GetProjectUseCase
-import cz.adamec.timotej.snag.projects.business.CanEditProjectEntitiesRule
+import cz.adamec.timotej.snag.projects.business.AreProjectEntitiesEditableRule
 import cz.adamec.timotej.snag.structures.be.ports.StructuresDb
 
 internal class DeleteFindingUseCaseImpl(
     private val findingsDb: FindingsDb,
     private val structuresDb: StructuresDb,
     private val getProjectUseCase: GetProjectUseCase,
-    private val canEditProjectEntitiesRule: CanEditProjectEntitiesRule,
+    private val areProjectEntitiesEditableRule: AreProjectEntitiesEditableRule,
 ) : DeleteFindingUseCase {
     override suspend operator fun invoke(request: DeleteFindingRequest): BackendFinding? {
         val finding = findingsDb.getFinding(request.findingId)
@@ -33,7 +33,7 @@ internal class DeleteFindingUseCaseImpl(
             val structure = structuresDb.getStructure(finding.structureId)
             if (structure != null) {
                 val project = getProjectUseCase(structure.projectId)
-                if (project != null && !canEditProjectEntitiesRule(project)) {
+                if (project != null && !areProjectEntitiesEditableRule(project)) {
                     return finding
                 }
             }

--- a/feat/findings/be/app/impl/src/main/kotlin/cz/adamec/timotej/snag/findings/be/app/impl/internal/SaveFindingUseCaseImpl.kt
+++ b/feat/findings/be/app/impl/src/main/kotlin/cz/adamec/timotej/snag/findings/be/app/impl/internal/SaveFindingUseCaseImpl.kt
@@ -17,20 +17,20 @@ import cz.adamec.timotej.snag.findings.be.app.api.SaveFindingUseCase
 import cz.adamec.timotej.snag.findings.be.app.impl.internal.LH.logger
 import cz.adamec.timotej.snag.findings.be.ports.FindingsDb
 import cz.adamec.timotej.snag.projects.be.app.api.GetProjectUseCase
-import cz.adamec.timotej.snag.projects.business.CanEditProjectEntitiesRule
+import cz.adamec.timotej.snag.projects.business.AreProjectEntitiesEditableRule
 import cz.adamec.timotej.snag.structures.be.ports.StructuresDb
 
 internal class SaveFindingUseCaseImpl(
     private val findingsDb: FindingsDb,
     private val structuresDb: StructuresDb,
     private val getProjectUseCase: GetProjectUseCase,
-    private val canEditProjectEntitiesRule: CanEditProjectEntitiesRule,
+    private val areProjectEntitiesEditableRule: AreProjectEntitiesEditableRule,
 ) : SaveFindingUseCase {
     override suspend operator fun invoke(finding: BackendFinding): BackendFinding? {
         val structure = structuresDb.getStructure(finding.structureId)
         if (structure != null) {
             val project = getProjectUseCase(structure.projectId)
-            if (project != null && !canEditProjectEntitiesRule(project)) {
+            if (project != null && !areProjectEntitiesEditableRule(project)) {
                 return findingsDb.getFinding(finding.id)
             }
         }

--- a/feat/inspections/be/app/impl/src/main/kotlin/cz/adamec/timotej/snag/feat/inspections/be/app/impl/internal/DeleteInspectionUseCaseImpl.kt
+++ b/feat/inspections/be/app/impl/src/main/kotlin/cz/adamec/timotej/snag/feat/inspections/be/app/impl/internal/DeleteInspectionUseCaseImpl.kt
@@ -18,18 +18,18 @@ import cz.adamec.timotej.snag.feat.inspections.be.app.impl.internal.LH.logger
 import cz.adamec.timotej.snag.feat.inspections.be.model.BackendInspection
 import cz.adamec.timotej.snag.feat.inspections.be.ports.InspectionsDb
 import cz.adamec.timotej.snag.projects.be.app.api.GetProjectUseCase
-import cz.adamec.timotej.snag.projects.business.CanEditProjectEntitiesRule
+import cz.adamec.timotej.snag.projects.business.AreProjectEntitiesEditableRule
 
 internal class DeleteInspectionUseCaseImpl(
     private val inspectionsDb: InspectionsDb,
     private val getProjectUseCase: GetProjectUseCase,
-    private val canEditProjectEntitiesRule: CanEditProjectEntitiesRule,
+    private val areProjectEntitiesEditableRule: AreProjectEntitiesEditableRule,
 ) : DeleteInspectionUseCase {
     override suspend operator fun invoke(request: DeleteInspectionRequest): BackendInspection? {
         val inspection = inspectionsDb.getInspection(request.inspectionId)
         if (inspection != null) {
             val project = getProjectUseCase(inspection.projectId)
-            if (project != null && !canEditProjectEntitiesRule(project)) {
+            if (project != null && !areProjectEntitiesEditableRule(project)) {
                 return inspection
             }
         }

--- a/feat/inspections/be/app/impl/src/main/kotlin/cz/adamec/timotej/snag/feat/inspections/be/app/impl/internal/SaveInspectionUseCaseImpl.kt
+++ b/feat/inspections/be/app/impl/src/main/kotlin/cz/adamec/timotej/snag/feat/inspections/be/app/impl/internal/SaveInspectionUseCaseImpl.kt
@@ -17,16 +17,16 @@ import cz.adamec.timotej.snag.feat.inspections.be.app.impl.internal.LH.logger
 import cz.adamec.timotej.snag.feat.inspections.be.model.BackendInspection
 import cz.adamec.timotej.snag.feat.inspections.be.ports.InspectionsDb
 import cz.adamec.timotej.snag.projects.be.app.api.GetProjectUseCase
-import cz.adamec.timotej.snag.projects.business.CanEditProjectEntitiesRule
+import cz.adamec.timotej.snag.projects.business.AreProjectEntitiesEditableRule
 
 internal class SaveInspectionUseCaseImpl(
     private val inspectionsDb: InspectionsDb,
     private val getProjectUseCase: GetProjectUseCase,
-    private val canEditProjectEntitiesRule: CanEditProjectEntitiesRule,
+    private val areProjectEntitiesEditableRule: AreProjectEntitiesEditableRule,
 ) : SaveInspectionUseCase {
     override suspend operator fun invoke(backendInspection: BackendInspection): BackendInspection? {
         val project = getProjectUseCase(backendInspection.projectId)
-        if (project != null && !canEditProjectEntitiesRule(project)) {
+        if (project != null && !areProjectEntitiesEditableRule(project)) {
             return inspectionsDb.getInspection(backendInspection.id)
         }
         logger.debug("Saving inspection {} to local storage.", backendInspection)

--- a/feat/projects/be/app/impl/src/main/kotlin/cz/adamec/timotej/snag/projects/be/app/impl/di/ProjectsAppModule.kt
+++ b/feat/projects/be/app/impl/src/main/kotlin/cz/adamec/timotej/snag/projects/be/app/impl/di/ProjectsAppModule.kt
@@ -42,7 +42,7 @@ import cz.adamec.timotej.snag.projects.business.CanAccessProjectRule
 import cz.adamec.timotej.snag.projects.business.CanAssignUserToProjectRule
 import cz.adamec.timotej.snag.projects.business.CanCloseProjectRule
 import cz.adamec.timotej.snag.projects.business.CanCreateProjectRule
-import cz.adamec.timotej.snag.projects.business.CanEditProjectEntitiesRule
+import cz.adamec.timotej.snag.projects.business.AreProjectEntitiesEditableRule
 import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
@@ -58,7 +58,7 @@ val projectsAppModule =
         factoryOf(::AssignUserToProjectUseCaseImpl) bind AssignUserToProjectUseCase::class
         factoryOf(::RemoveUserFromProjectUseCaseImpl) bind RemoveUserFromProjectUseCase::class
         factoryOf(::IsClientReferencedByProjectUseCaseImpl) bind IsClientReferencedByProjectUseCase::class
-        factoryOf(::CanEditProjectEntitiesRule)
+        factoryOf(::AreProjectEntitiesEditableRule)
         factoryOf(::CanAccessProjectRule)
         factoryOf(::CanAssignUserToProjectRule)
         factoryOf(::CanCreateProjectRule)

--- a/feat/projects/business/rules/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/business/AreProjectEntitiesEditableRule.kt
+++ b/feat/projects/business/rules/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/business/AreProjectEntitiesEditableRule.kt
@@ -12,6 +12,6 @@
 
 package cz.adamec.timotej.snag.projects.business
 
-class CanEditProjectEntitiesRule {
+class AreProjectEntitiesEditableRule {
     operator fun invoke(project: Project) = !project.isClosed
 }

--- a/feat/projects/business/rules/src/commonTest/kotlin/cz/adamec/timotej/snag/projects/business/AreProjectEntitiesEditableRuleTest.kt
+++ b/feat/projects/business/rules/src/commonTest/kotlin/cz/adamec/timotej/snag/projects/business/AreProjectEntitiesEditableRuleTest.kt
@@ -18,8 +18,8 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.uuid.Uuid
 
-class CanEditProjectEntitiesRuleTest {
-    private val rule = CanEditProjectEntitiesRule()
+class AreProjectEntitiesEditableRuleTest {
+    private val rule = AreProjectEntitiesEditableRule()
 
     private fun createProject(isClosed: Boolean) =
         object : Project {

--- a/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/di/ProjectsAppModule.kt
+++ b/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/di/ProjectsAppModule.kt
@@ -12,7 +12,8 @@
 
 package cz.adamec.timotej.snag.projects.fe.app.impl.di
 
-import cz.adamec.timotej.snag.projects.business.CanEditProjectEntitiesRule
+import cz.adamec.timotej.snag.projects.business.AreProjectEntitiesEditableRule
+import cz.adamec.timotej.snag.projects.business.CanAccessProjectRule
 import cz.adamec.timotej.snag.projects.fe.app.api.CanEditProjectEntitiesUseCase
 import cz.adamec.timotej.snag.projects.fe.app.api.CascadeDeleteLocalAssignmentsByProjectIdUseCase
 import cz.adamec.timotej.snag.projects.fe.app.api.CascadeRestoreLocalAssignmentsByProjectIdUseCase
@@ -51,7 +52,8 @@ val projectsAppModule =
         factoryOf(::SetProjectClosedUseCaseImpl) bind SetProjectClosedUseCase::class
         factoryOf(::CanEditProjectEntitiesUseCaseImpl) bind CanEditProjectEntitiesUseCase::class
         factoryOf(::IsClientReferencedByProjectUseCaseImpl) bind IsClientReferencedByProjectUseCase::class
-        factoryOf(::CanEditProjectEntitiesRule)
+        factoryOf(::AreProjectEntitiesEditableRule)
+        factoryOf(::CanAccessProjectRule)
         factoryOf(::GetProjectAssignmentsUseCaseImpl) bind GetProjectAssignmentsUseCase::class
         factoryOf(::CascadeDeleteLocalAssignmentsByProjectIdUseCaseImpl) bind CascadeDeleteLocalAssignmentsByProjectIdUseCase::class
         factoryOf(::CascadeRestoreLocalAssignmentsByProjectIdUseCaseImpl) bind CascadeRestoreLocalAssignmentsByProjectIdUseCase::class

--- a/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/CanEditProjectEntitiesUseCaseImpl.kt
+++ b/feat/projects/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/CanEditProjectEntitiesUseCaseImpl.kt
@@ -13,28 +13,42 @@
 package cz.adamec.timotej.snag.projects.fe.app.impl.internal
 
 import cz.adamec.timotej.snag.core.network.fe.OfflineFirstDataResult
-import cz.adamec.timotej.snag.projects.business.CanEditProjectEntitiesRule
+import cz.adamec.timotej.snag.projects.business.AreProjectEntitiesEditableRule
+import cz.adamec.timotej.snag.projects.business.CanAccessProjectRule
 import cz.adamec.timotej.snag.projects.fe.app.api.CanEditProjectEntitiesUseCase
+import cz.adamec.timotej.snag.projects.fe.ports.ProjectAssignmentsDb
 import cz.adamec.timotej.snag.projects.fe.ports.ProjectsDb
+import cz.adamec.timotej.snag.users.fe.app.api.GetCurrentUserFlowUseCase
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.map
 import kotlin.uuid.Uuid
 
 class CanEditProjectEntitiesUseCaseImpl(
     private val projectsDb: ProjectsDb,
-    private val canEditProjectEntitiesRule: CanEditProjectEntitiesRule,
+    private val projectAssignmentsDb: ProjectAssignmentsDb,
+    private val getCurrentUserFlowUseCase: GetCurrentUserFlowUseCase,
+    private val canAccessProjectRule: CanAccessProjectRule,
+    private val areProjectEntitiesEditableRule: AreProjectEntitiesEditableRule,
 ) : CanEditProjectEntitiesUseCase {
     override operator fun invoke(projectId: Uuid): Flow<Boolean> =
-        projectsDb
-            .getProjectFlow(projectId)
-            .map { result ->
-                when (result) {
-                    is OfflineFirstDataResult.Success ->
-                        result.data?.let { canEditProjectEntitiesRule(it) } ?: true
-                    is OfflineFirstDataResult.ProgrammerError -> true
-                }
-            }.catch { emit(true) }
+        combine(
+            getCurrentUserFlowUseCase(),
+            projectsDb.getProjectFlow(projectId),
+            projectAssignmentsDb.getAssignedUserIdsFlow(projectId),
+        ) { userResult, projectResult, assignmentsResult ->
+            val user = (userResult as? OfflineFirstDataResult.Success)?.data
+            val project = (projectResult as? OfflineFirstDataResult.Success)?.data
+            val assignedUserIds = (assignmentsResult as? OfflineFirstDataResult.Success)?.data
+
+            if (user == null || project == null || assignedUserIds == null) return@combine false
+
+            canAccessProjectRule(
+                user = user,
+                project = project,
+                assignedUserIds = assignedUserIds,
+            ) && areProjectEntitiesEditableRule(project)
+        }.catch { emit(false) }
             .distinctUntilChanged()
 }

--- a/feat/projects/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/CanEditProjectEntitiesUseCaseImplTest.kt
+++ b/feat/projects/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/projects/fe/app/impl/internal/CanEditProjectEntitiesUseCaseImplTest.kt
@@ -12,13 +12,16 @@
 
 package cz.adamec.timotej.snag.projects.fe.app.impl.internal
 
+import cz.adamec.timotej.snag.authorization.business.UserRole
 import cz.adamec.timotej.snag.core.foundation.common.Timestamp
 import cz.adamec.timotej.snag.core.foundation.common.UuidProvider
-import cz.adamec.timotej.snag.core.network.fe.OfflineFirstDataResult
 import cz.adamec.timotej.snag.projects.app.model.AppProjectData
 import cz.adamec.timotej.snag.projects.fe.app.api.CanEditProjectEntitiesUseCase
+import cz.adamec.timotej.snag.projects.fe.driven.test.FakeProjectAssignmentsDb
 import cz.adamec.timotej.snag.projects.fe.driven.test.FakeProjectsDb
 import cz.adamec.timotej.snag.testinfra.fe.FrontendKoinInitializedTest
+import cz.adamec.timotej.snag.users.app.model.AppUserData
+import cz.adamec.timotej.snag.users.fe.driven.test.FakeUsersDb
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
@@ -26,27 +29,51 @@ import org.koin.test.inject
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CanEditProjectEntitiesUseCaseImplTest : FrontendKoinInitializedTest() {
     private val fakeProjectsDb: FakeProjectsDb by inject()
+    private val fakeUsersDb: FakeUsersDb by inject()
+    private val fakeProjectAssignmentsDb: FakeProjectAssignmentsDb by inject()
     private val useCase: CanEditProjectEntitiesUseCase by inject()
 
+    private val currentUserId = Uuid.parse("00000000-0000-0000-0000-000000000001")
     private val projectId = UuidProvider.getUuid()
 
+    private fun seedCurrentUser(role: UserRole? = UserRole.PASSPORT_LEAD) {
+        fakeUsersDb.setUser(
+            AppUserData(
+                id = currentUserId,
+                entraId = "entra-id",
+                email = "user@example.com",
+                role = role,
+                updatedAt = Timestamp(100L),
+            ),
+        )
+    }
+
+    private fun seedProject(
+        isClosed: Boolean = false,
+        creatorId: Uuid = currentUserId,
+    ) {
+        fakeProjectsDb.setProject(
+            AppProjectData(
+                id = projectId,
+                name = "Test Project",
+                address = "Address",
+                creatorId = creatorId,
+                isClosed = isClosed,
+                updatedAt = Timestamp(100L),
+            ),
+        )
+    }
+
     @Test
-    fun `returns true for open project`() =
+    fun `returns true for open project where user is creator`() =
         runTest(testDispatcher) {
-            fakeProjectsDb.setProject(
-                AppProjectData(
-                    id = projectId,
-                    name = "Open Project",
-                    address = "Address",
-                    creatorId = UuidProvider.getUuid(),
-                    isClosed = false,
-                    updatedAt = Timestamp(100L),
-                ),
-            )
+            seedCurrentUser()
+            seedProject(isClosed = false, creatorId = currentUserId)
 
             val result = useCase(projectId).first()
 
@@ -54,18 +81,10 @@ class CanEditProjectEntitiesUseCaseImplTest : FrontendKoinInitializedTest() {
         }
 
     @Test
-    fun `returns false for closed project`() =
+    fun `returns false for closed project even when user is creator`() =
         runTest(testDispatcher) {
-            fakeProjectsDb.setProject(
-                AppProjectData(
-                    id = projectId,
-                    name = "Closed Project",
-                    address = "Address",
-                    creatorId = UuidProvider.getUuid(),
-                    isClosed = true,
-                    updatedAt = Timestamp(100L),
-                ),
-            )
+            seedCurrentUser()
+            seedProject(isClosed = true, creatorId = currentUserId)
 
             val result = useCase(projectId).first()
 
@@ -73,21 +92,59 @@ class CanEditProjectEntitiesUseCaseImplTest : FrontendKoinInitializedTest() {
         }
 
     @Test
-    fun `returns true when project not found`() =
+    fun `returns true for open project where user is assigned`() =
         runTest(testDispatcher) {
+            val otherCreator = UuidProvider.getUuid()
+            seedCurrentUser()
+            seedProject(isClosed = false, creatorId = otherCreator)
+            fakeProjectAssignmentsDb.setAssignments(projectId, setOf(currentUserId))
+
             val result = useCase(projectId).first()
 
             assertTrue(result)
         }
 
     @Test
-    fun `returns true on ProgrammerError`() =
+    fun `returns false for open project where user has no access`() =
         runTest(testDispatcher) {
-            fakeProjectsDb.forcedFailure =
-                OfflineFirstDataResult.ProgrammerError(RuntimeException("DB error"))
+            val otherCreator = UuidProvider.getUuid()
+            seedCurrentUser(role = UserRole.PASSPORT_TECHNICIAN)
+            seedProject(isClosed = false, creatorId = otherCreator)
+
+            val result = useCase(projectId).first()
+
+            assertFalse(result)
+        }
+
+    @Test
+    fun `returns true for open project when user is administrator`() =
+        runTest(testDispatcher) {
+            val otherCreator = UuidProvider.getUuid()
+            seedCurrentUser(role = UserRole.ADMINISTRATOR)
+            seedProject(isClosed = false, creatorId = otherCreator)
 
             val result = useCase(projectId).first()
 
             assertTrue(result)
+        }
+
+    @Test
+    fun `returns false when project not found`() =
+        runTest(testDispatcher) {
+            seedCurrentUser()
+
+            val result = useCase(projectId).first()
+
+            assertFalse(result)
+        }
+
+    @Test
+    fun `returns false when user not found`() =
+        runTest(testDispatcher) {
+            seedProject()
+
+            val result = useCase(projectId).first()
+
+            assertFalse(result)
         }
 }

--- a/feat/structures/be/app/impl/src/main/kotlin/cz/adamec/timotej/snag/structures/be/app/impl/internal/DeleteStructureUseCaseImpl.kt
+++ b/feat/structures/be/app/impl/src/main/kotlin/cz/adamec/timotej/snag/structures/be/app/impl/internal/DeleteStructureUseCaseImpl.kt
@@ -14,7 +14,7 @@ package cz.adamec.timotej.snag.structures.be.app.impl.internal
 
 import cz.adamec.timotej.snag.feat.structures.be.model.BackendStructure
 import cz.adamec.timotej.snag.projects.be.app.api.GetProjectUseCase
-import cz.adamec.timotej.snag.projects.business.CanEditProjectEntitiesRule
+import cz.adamec.timotej.snag.projects.business.AreProjectEntitiesEditableRule
 import cz.adamec.timotej.snag.structures.be.app.api.DeleteStructureUseCase
 import cz.adamec.timotej.snag.structures.be.app.api.model.DeleteStructureRequest
 import cz.adamec.timotej.snag.structures.be.app.impl.internal.LH.logger
@@ -23,13 +23,13 @@ import cz.adamec.timotej.snag.structures.be.ports.StructuresDb
 internal class DeleteStructureUseCaseImpl(
     private val structuresDb: StructuresDb,
     private val getProjectUseCase: GetProjectUseCase,
-    private val canEditProjectEntitiesRule: CanEditProjectEntitiesRule,
+    private val areProjectEntitiesEditableRule: AreProjectEntitiesEditableRule,
 ) : DeleteStructureUseCase {
     override suspend operator fun invoke(request: DeleteStructureRequest): BackendStructure? {
         val structure = structuresDb.getStructure(request.structureId)
         if (structure != null) {
             val project = getProjectUseCase(structure.projectId)
-            if (project != null && !canEditProjectEntitiesRule(project)) {
+            if (project != null && !areProjectEntitiesEditableRule(project)) {
                 return structure
             }
         }

--- a/feat/structures/be/app/impl/src/main/kotlin/cz/adamec/timotej/snag/structures/be/app/impl/internal/SaveStructureUseCaseImpl.kt
+++ b/feat/structures/be/app/impl/src/main/kotlin/cz/adamec/timotej/snag/structures/be/app/impl/internal/SaveStructureUseCaseImpl.kt
@@ -14,7 +14,7 @@ package cz.adamec.timotej.snag.structures.be.app.impl.internal
 
 import cz.adamec.timotej.snag.feat.structures.be.model.BackendStructure
 import cz.adamec.timotej.snag.projects.be.app.api.GetProjectUseCase
-import cz.adamec.timotej.snag.projects.business.CanEditProjectEntitiesRule
+import cz.adamec.timotej.snag.projects.business.AreProjectEntitiesEditableRule
 import cz.adamec.timotej.snag.structures.be.app.api.SaveStructureUseCase
 import cz.adamec.timotej.snag.structures.be.app.impl.internal.LH.logger
 import cz.adamec.timotej.snag.structures.be.ports.StructuresDb
@@ -22,11 +22,11 @@ import cz.adamec.timotej.snag.structures.be.ports.StructuresDb
 internal class SaveStructureUseCaseImpl(
     private val structuresDb: StructuresDb,
     private val getProjectUseCase: GetProjectUseCase,
-    private val canEditProjectEntitiesRule: CanEditProjectEntitiesRule,
+    private val areProjectEntitiesEditableRule: AreProjectEntitiesEditableRule,
 ) : SaveStructureUseCase {
     override suspend operator fun invoke(backendStructure: BackendStructure): BackendStructure? {
         val project = getProjectUseCase(backendStructure.projectId)
-        if (project != null && !canEditProjectEntitiesRule(project)) {
+        if (project != null && !areProjectEntitiesEditableRule(project)) {
             return structuresDb.getStructure(backendStructure.id)
         }
         logger.debug("Saving structure {} to local storage.", backendStructure)

--- a/feat/users/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/users/fe/app/api/GetCurrentUserFlowUseCase.kt
+++ b/feat/users/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/users/fe/app/api/GetCurrentUserFlowUseCase.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.users.fe.app.api
+
+import cz.adamec.timotej.snag.core.network.fe.OfflineFirstDataResult
+import cz.adamec.timotej.snag.users.app.model.AppUser
+import kotlinx.coroutines.flow.Flow
+
+interface GetCurrentUserFlowUseCase {
+    operator fun invoke(): Flow<OfflineFirstDataResult<AppUser?>>
+}

--- a/feat/users/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/users/fe/app/impl/di/UsersAppModule.kt
+++ b/feat/users/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/users/fe/app/impl/di/UsersAppModule.kt
@@ -14,9 +14,11 @@ package cz.adamec.timotej.snag.users.fe.app.impl.di
 
 import cz.adamec.timotej.snag.sync.fe.app.api.handler.PullSyncOperationHandler
 import cz.adamec.timotej.snag.users.fe.app.api.ChangeUserRoleUseCase
+import cz.adamec.timotej.snag.users.fe.app.api.GetCurrentUserFlowUseCase
 import cz.adamec.timotej.snag.users.fe.app.api.GetCurrentUserUseCase
 import cz.adamec.timotej.snag.users.fe.app.api.GetUsersUseCase
 import cz.adamec.timotej.snag.users.fe.app.impl.internal.ChangeUserRoleUseCaseImpl
+import cz.adamec.timotej.snag.users.fe.app.impl.internal.GetCurrentUserFlowUseCaseImpl
 import cz.adamec.timotej.snag.users.fe.app.impl.internal.GetCurrentUserUseCaseImpl
 import cz.adamec.timotej.snag.users.fe.app.impl.internal.GetUsersUseCaseImpl
 import cz.adamec.timotej.snag.users.fe.app.impl.internal.sync.UserPullSyncHandler
@@ -28,6 +30,7 @@ val usersAppModule =
     module {
         factoryOf(::GetUsersUseCaseImpl) bind GetUsersUseCase::class
         factoryOf(::GetCurrentUserUseCaseImpl) bind GetCurrentUserUseCase::class
+        factoryOf(::GetCurrentUserFlowUseCaseImpl) bind GetCurrentUserFlowUseCase::class
         factoryOf(::ChangeUserRoleUseCaseImpl) bind ChangeUserRoleUseCase::class
         factoryOf(::UserPullSyncHandler) bind PullSyncOperationHandler::class
     }

--- a/feat/users/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/users/fe/app/impl/internal/GetCurrentUserFlowUseCaseImpl.kt
+++ b/feat/users/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/users/fe/app/impl/internal/GetCurrentUserFlowUseCaseImpl.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.users.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.core.network.fe.OfflineFirstDataResult
+import cz.adamec.timotej.snag.users.app.model.AppUser
+import cz.adamec.timotej.snag.users.fe.app.api.GetCurrentUserFlowUseCase
+import cz.adamec.timotej.snag.users.fe.app.api.GetCurrentUserUseCase
+import cz.adamec.timotej.snag.users.fe.ports.UsersDb
+import kotlinx.coroutines.flow.Flow
+
+internal class GetCurrentUserFlowUseCaseImpl(
+    private val getCurrentUserUseCase: GetCurrentUserUseCase,
+    private val usersDb: UsersDb,
+) : GetCurrentUserFlowUseCase {
+    override operator fun invoke(): Flow<OfflineFirstDataResult<AppUser?>> =
+        usersDb.getUserFlow(getCurrentUserUseCase())
+}

--- a/implementation-guide.md
+++ b/implementation-guide.md
@@ -133,7 +133,7 @@ The following features are new compared to the original analysis (which had no r
 - [ ] **Frontend**: hide/show UI elements based on role; do not rely solely on frontend gating.
   - Current state: **zero role-based UI gating**. Current user is a hardcoded UUID (`GetCurrentUserUseCaseImpl`) with TODO to replace with EntraID. FE does not know the current user's role.
   - All buttons (create project, close/reopen, edit, delete, report download) are visible unconditionally — only gated by project state (`isClosed`), not user role or access.
-  - Shared KMP rules (`CanCreateProjectRule`, `CanCloseProjectRule`, `CanAccessProjectRule`, `CanAssignUserToProjectRule`) exist but are unused on FE.
+  - Shared KMP rules (`CanCreateProjectRule`, `CanCloseProjectRule`, `CanAccessProjectRule`, `CanAssignUserToProjectRule`) exist. `CanAccessProjectRule` + `AreProjectEntitiesEditableRule` (renamed from `CanEditProjectEntitiesRule`) are now composed in `CanEditProjectEntitiesUseCaseImpl` to gate entity editing by both access and project state. Other rules still unused on FE.
   - **Stale data issue**: when a user's role changes or they are unassigned, the local DB retains all previously synced data (projects, structures, findings, photos). Backend stops serving new updates, but old data remains readable offline. Backend blocks unauthorized writes (403), so no data corruption, but user can still read data they should no longer access. Inherent to offline-first architecture — possible fix: detect projects no longer returned by backend sync and purge local copies.
 
 ### Detailed Permission Matrix


### PR DESCRIPTION
## Problem Statement

`CanEditProjectEntitiesRule` had a misleading name — it sounded like an authorization check ("can user edit?") but only checked project state ("is project open?"). Additionally, the FE `CanEditProjectEntitiesUseCaseImpl` only checked project state, not whether the user actually has access to the project. This meant edit buttons were shown to users who shouldn't have access.

## Solution

1. **Rename** `CanEditProjectEntitiesRule` → `AreProjectEntitiesEditableRule` — clarifies it's a state query, not an authorization decision
2. **Compose** `CanAccessProjectRule` into the FE `CanEditProjectEntitiesUseCaseImpl` — now checks both user access (admin/creator/assigned via `CanAccessProjectRule`) AND project state (open via `AreProjectEntitiesEditableRule`)
3. **Add** `GetCurrentUserFlowUseCase` — exposes current user as a reactive Flow without leaking `UsersDb` port across feature boundaries

The composition happens at the FE use case level, not in the business rule. On BE, the route layer handles access (403) and the use case layer handles state (return server entity for sync) — these remain separate concerns.

## Test Coverage

- `CanEditProjectEntitiesUseCaseImplTest` — 7 test cases covering: creator access + open/closed, assigned user access, no access, admin access, project not found, user not found
- `AreProjectEntitiesEditableRuleTest` — renamed, unchanged (open/closed state)

## References

PR 2 of 3 for completing backend authorization:
1. PR #149 (merged) — FE project assignments
2. **This PR** — Rule rename + FE access composition
3. PR 3 — Wire BE authorization to all remaining routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)