### PR TITLE
Fix Android test source set autowiring

### DIFF
--- a/build-logic/src/main/kotlin/cz/adamec/timotej/snag/buildsrc/configuration/MultiplatformModuleSetup.kt
+++ b/build-logic/src/main/kotlin/cz/adamec/timotej/snag/buildsrc/configuration/MultiplatformModuleSetup.kt
@@ -116,12 +116,18 @@ private fun NamedDomainObjectContainer<KotlinSourceSet>.configureIntermediateSou
     val suffix = if (isTest) "Test" else "Main"
     val common = getByName("common$suffix")
 
-    fun getOrCreate(name: String) = maybeCreate("$name$suffix")
+    fun getOrCreate(name: String): KotlinSourceSet {
+        val resolvedName = if (name == "android" && isTest) "androidUnitTest" else "$name$suffix"
+        return maybeCreate(resolvedName)
+    }
+
+    fun androidInstrumented() = if (isTest) maybeCreate("androidInstrumentedTest") else null
 
     val nonWeb = create("nonWeb$suffix") {
         dependsOn(common)
     }
     getOrCreate("android").dependsOn(nonWeb)
+    androidInstrumented()?.dependsOn(nonWeb)
     getOrCreate("ios").dependsOn(nonWeb)
     getOrCreate("jvm").dependsOn(nonWeb)
 
@@ -139,6 +145,7 @@ private fun NamedDomainObjectContainer<KotlinSourceSet>.configureIntermediateSou
         dependsOn(common)
     }
     getOrCreate("android").dependsOn(nonJvm)
+    androidInstrumented()?.dependsOn(nonJvm)
     getOrCreate("ios").dependsOn(nonJvm)
     getOrCreate("web").dependsOn(nonJvm)
 }


### PR DESCRIPTION
## Problem Statement

The `configureIntermediateSourceSets` function in the convention plugin was wiring intermediate source sets (`nonWeb`, `nonJvm`) to `androidTest` instead of the correct `androidUnitTest`. Additionally, `androidInstrumentedTest` was not wired into the intermediate source set hierarchy at all.

## Solution

- Changed the `getOrCreate` helper to resolve `"android"` to `"androidUnitTest"` (instead of `"androidTest"`) when configuring test source sets
- Added `androidInstrumentedTest` to depend on the same intermediate source sets (`nonWeb`, `nonJvm`) so instrumented tests also have access to shared test code

## Test Coverage

### Unit Tests
- Convention plugin logic — no dedicated tests; verified by successful Gradle sync across all modules

### Manual Testing
- [ ] Run `./gradlew check` — all modules resolve source sets correctly
- [ ] Verify `nonWebTest` code is accessible from `androidUnitTest` source sets
- [ ] Verify `nonWebTest` code is accessible from `androidInstrumentedTest` source sets

## References
- None