### PR TITLE
Fix desktop release launch crashes (SQLite path, okio, Unsafe)

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -83,7 +83,7 @@ compose.desktop {
             packageName = SNAG_NAMESPACE
             packageVersion = SnagVersioning.semanticVersion(project).get()
 
-            modules("java.sql")
+            modules("java.sql", "jdk.unsupported")
         }
     }
 }

--- a/composeApp/proguard-desktop.pro
+++ b/composeApp/proguard-desktop.pro
@@ -38,6 +38,17 @@
 -keep class org.sqlite.** { *; }
 -keep class * implements java.sql.Driver { *; }
 
+# OkHttp + okio: ProGuard's optimizer may specialize Okio.buffer(Sink) into a
+# variant whose declared return type RealBufferedSink mismatches the actual
+# returned BufferedSink, producing a JVM VerifyError on first network IO.
+# Pin these libraries from optimization to keep their bytecode signatures intact.
+-keep class okio.** { *; }
+-keepclassmembers class okio.** { *; }
+-keep class okhttp3.** { *; }
+-keepclassmembers class okhttp3.** { *; }
+-dontwarn okio.**
+-dontwarn okhttp3.**
+
 # SLF4J service provider
 -keep class * implements org.slf4j.spi.SLF4JServiceProvider { *; }
 

--- a/feat/sync/fe/driven/impl/build.gradle.kts
+++ b/feat/sync/fe/driven/impl/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(project(":lib:database:fe"))
+            implementation(project(":lib:configuration:fe:api"))
         }
     }
 }

--- a/feat/sync/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/sync/fe/driven/impl/di/SyncDrivenModule.kt
+++ b/feat/sync/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/sync/fe/driven/impl/di/SyncDrivenModule.kt
@@ -12,6 +12,7 @@
 
 package cz.adamec.timotej.snag.sync.fe.driven.impl.di
 
+import cz.adamec.timotej.snag.configuration.fe.FrontendRunConfig
 import cz.adamec.timotej.snag.core.foundation.common.di.getIoDispatcher
 import cz.adamec.timotej.snag.lib.database.fe.sqlDelightDatabaseModule
 import cz.adamec.timotej.snag.sync.fe.driven.impl.RealPullSyncTimestampDb
@@ -29,6 +30,7 @@ private val syncDatabaseModule =
     sqlDelightDatabaseModule(
         schema = SyncDatabase.Schema,
         name = "sync.db",
+        appId = FrontendRunConfig.namespace,
         qualifier = named("syncDb"),
     )
 

--- a/featShared/database/fe/driven/impl/build.gradle.kts
+++ b/featShared/database/fe/driven/impl/build.gradle.kts
@@ -19,6 +19,7 @@ kotlin {
         commonMain.dependencies {
             implementation(project(":core:foundation:fe"))
             implementation(project(":lib:database:fe"))
+            implementation(project(":lib:configuration:fe:api"))
         }
     }
 }

--- a/featShared/database/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/featShared/database/fe/driven/impl/di/DatabaseModule.kt
+++ b/featShared/database/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/featShared/database/fe/driven/impl/di/DatabaseModule.kt
@@ -12,6 +12,7 @@
 
 package cz.adamec.timotej.snag.featShared.database.fe.driven.impl.di
 
+import cz.adamec.timotej.snag.configuration.fe.FrontendRunConfig
 import cz.adamec.timotej.snag.featShared.database.fe.driven.api.db.ClassicFindingEntityQueries
 import cz.adamec.timotej.snag.featShared.database.fe.driven.api.db.ClientEntityQueries
 import cz.adamec.timotej.snag.featShared.database.fe.driven.api.db.FindingCoordinateEntityQueries
@@ -33,6 +34,7 @@ private val snagDatabaseInfraModule =
     sqlDelightDatabaseModule(
         schema = SnagDatabase.Schema,
         name = "snag.db",
+        appId = FrontendRunConfig.namespace,
         qualifier = named("snagDb"),
     )
 

--- a/lib/database/fe/src/androidMain/kotlin/cz/adamec/timotej/snag/lib/database/fe/SqlDriverFactory.android.kt
+++ b/lib/database/fe/src/androidMain/kotlin/cz/adamec/timotej/snag/lib/database/fe/SqlDriverFactory.android.kt
@@ -23,6 +23,7 @@ import org.koin.core.scope.Scope
 actual fun Scope.createPlatformSqlDriver(
     schema: SqlSchema<QueryResult.AsyncValue<Unit>>,
     name: String,
+    appId: String,
 ): SqlDriver =
     AndroidSqliteDriver(
         schema = schema.synchronous(),

--- a/lib/database/fe/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/database/fe/SqlDelightDatabaseModule.kt
+++ b/lib/database/fe/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/database/fe/SqlDelightDatabaseModule.kt
@@ -24,10 +24,11 @@ import org.koin.dsl.module
 fun sqlDelightDatabaseModule(
     schema: SqlSchema<QueryResult.AsyncValue<Unit>>,
     name: String,
+    appId: String,
     qualifier: Qualifier,
 ) = module {
     single(qualifier) {
-        createPlatformSqlDriver(schema, name)
+        createPlatformSqlDriver(schema = schema, name = name, appId = appId)
     } bind SqlDriver::class
 
     single<Initializer>(qualifier) {

--- a/lib/database/fe/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/database/fe/SqlDriverFactory.kt
+++ b/lib/database/fe/src/commonMain/kotlin/cz/adamec/timotej/snag/lib/database/fe/SqlDriverFactory.kt
@@ -20,4 +20,5 @@ import org.koin.core.scope.Scope
 expect fun Scope.createPlatformSqlDriver(
     schema: SqlSchema<QueryResult.AsyncValue<Unit>>,
     name: String,
+    appId: String,
 ): SqlDriver

--- a/lib/database/fe/src/iosMain/kotlin/cz/adamec/timotej/snag/lib/database/fe/SqlDriverFactory.ios.kt
+++ b/lib/database/fe/src/iosMain/kotlin/cz/adamec/timotej/snag/lib/database/fe/SqlDriverFactory.ios.kt
@@ -22,6 +22,7 @@ import org.koin.core.scope.Scope
 actual fun Scope.createPlatformSqlDriver(
     schema: SqlSchema<QueryResult.AsyncValue<Unit>>,
     name: String,
+    appId: String,
 ): SqlDriver =
     NativeSqliteDriver(
         schema = schema.synchronous(),

--- a/lib/database/fe/src/jvmMain/kotlin/cz/adamec/timotej/snag/lib/database/fe/JvmAppDatabasePath.kt
+++ b/lib/database/fe/src/jvmMain/kotlin/cz/adamec/timotej/snag/lib/database/fe/JvmAppDatabasePath.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.lib.database.fe
+
+internal fun resolveJvmAppDatabasePath(
+    osName: String,
+    userHome: String,
+    appData: String?,
+    xdgDataHome: String?,
+    appId: String,
+    dbName: String,
+): String {
+    val baseDir =
+        when {
+            osName.contains(other = "mac", ignoreCase = true) ||
+                osName.contains(other = "darwin", ignoreCase = true) ->
+                "$userHome/Library/Application Support"
+            osName.contains(other = "win", ignoreCase = true) ->
+                appData?.takeIf { it.isNotBlank() } ?: "$userHome/AppData/Roaming"
+            else ->
+                xdgDataHome?.takeIf { it.isNotBlank() } ?: "$userHome/.local/share"
+        }
+    return "$baseDir/$appId/$dbName"
+}

--- a/lib/database/fe/src/jvmMain/kotlin/cz/adamec/timotej/snag/lib/database/fe/SqlDriverFactory.jvm.kt
+++ b/lib/database/fe/src/jvmMain/kotlin/cz/adamec/timotej/snag/lib/database/fe/SqlDriverFactory.jvm.kt
@@ -18,12 +18,25 @@ import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import org.koin.core.scope.Scope
+import java.io.File
 
 actual fun Scope.createPlatformSqlDriver(
     schema: SqlSchema<QueryResult.AsyncValue<Unit>>,
     name: String,
-): SqlDriver =
-    JdbcSqliteDriver(
-        url = "jdbc:sqlite:$name",
+    appId: String,
+): SqlDriver {
+    val absolutePath =
+        resolveJvmAppDatabasePath(
+            osName = System.getProperty("os.name").orEmpty(),
+            userHome = System.getProperty("user.home").orEmpty(),
+            appData = System.getenv("APPDATA"),
+            xdgDataHome = System.getenv("XDG_DATA_HOME"),
+            appId = appId,
+            dbName = name,
+        )
+    File(absolutePath).parentFile?.mkdirs()
+    return JdbcSqliteDriver(
+        url = "jdbc:sqlite:$absolutePath",
         schema = schema.synchronous(),
     )
+}

--- a/lib/database/fe/src/jvmTest/kotlin/cz/adamec/timotej/snag/lib/database/fe/JvmAppDatabasePathTest.kt
+++ b/lib/database/fe/src/jvmTest/kotlin/cz/adamec/timotej/snag/lib/database/fe/JvmAppDatabasePathTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.lib.database.fe
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JvmAppDatabasePathTest {
+    @Test
+    fun macOsResolvesUnderApplicationSupport() {
+        val path =
+            resolveJvmAppDatabasePath(
+                osName = "Mac OS X",
+                userHome = "/Users/tim",
+                appData = null,
+                xdgDataHome = null,
+                appId = "cz.adamec.timotej.snag",
+                dbName = "snag.db",
+            )
+
+        assertEquals(
+            expected = "/Users/tim/Library/Application Support/cz.adamec.timotej.snag/snag.db",
+            actual = path,
+        )
+    }
+
+    @Test
+    fun windowsUsesAppDataEnvWhenSet() {
+        val path =
+            resolveJvmAppDatabasePath(
+                osName = "Windows 11",
+                userHome = """C:\Users\Tim""",
+                appData = """C:\Users\Tim\AppData\Roaming""",
+                xdgDataHome = null,
+                appId = "cz.adamec.timotej.snag",
+                dbName = "snag.db",
+            )
+
+        assertEquals(
+            expected = """C:\Users\Tim\AppData\Roaming/cz.adamec.timotej.snag/snag.db""",
+            actual = path,
+        )
+    }
+
+    @Test
+    fun windowsFallsBackToHomeAppDataRoamingWhenEnvMissing() {
+        val path =
+            resolveJvmAppDatabasePath(
+                osName = "Windows 11",
+                userHome = """C:\Users\Tim""",
+                appData = null,
+                xdgDataHome = null,
+                appId = "cz.adamec.timotej.snag",
+                dbName = "snag.db",
+            )
+
+        assertEquals(
+            expected = """C:\Users\Tim/AppData/Roaming/cz.adamec.timotej.snag/snag.db""",
+            actual = path,
+        )
+    }
+
+    @Test
+    fun linuxUsesXdgDataHomeWhenSet() {
+        val path =
+            resolveJvmAppDatabasePath(
+                osName = "Linux",
+                userHome = "/home/tim",
+                appData = null,
+                xdgDataHome = "/home/tim/.custom-data",
+                appId = "cz.adamec.timotej.snag",
+                dbName = "snag.db",
+            )
+
+        assertEquals(
+            expected = "/home/tim/.custom-data/cz.adamec.timotej.snag/snag.db",
+            actual = path,
+        )
+    }
+
+    @Test
+    fun linuxFallsBackToLocalShareWhenXdgMissing() {
+        val path =
+            resolveJvmAppDatabasePath(
+                osName = "Linux",
+                userHome = "/home/tim",
+                appData = null,
+                xdgDataHome = null,
+                appId = "cz.adamec.timotej.snag",
+                dbName = "snag.db",
+            )
+
+        assertEquals(
+            expected = "/home/tim/.local/share/cz.adamec.timotej.snag/snag.db",
+            actual = path,
+        )
+    }
+
+    @Test
+    fun unknownOsTreatedAsLinuxLike() {
+        val path =
+            resolveJvmAppDatabasePath(
+                osName = "FreeBSD",
+                userHome = "/home/tim",
+                appData = null,
+                xdgDataHome = null,
+                appId = "cz.adamec.timotej.snag",
+                dbName = "snag.db",
+            )
+
+        assertEquals(
+            expected = "/home/tim/.local/share/cz.adamec.timotej.snag/snag.db",
+            actual = path,
+        )
+    }
+
+    @Test
+    fun blankXdgDataHomeFallsBackToLocalShare() {
+        val path =
+            resolveJvmAppDatabasePath(
+                osName = "Linux",
+                userHome = "/home/tim",
+                appData = null,
+                xdgDataHome = "",
+                appId = "cz.adamec.timotej.snag",
+                dbName = "snag.db",
+            )
+
+        assertEquals(
+            expected = "/home/tim/.local/share/cz.adamec.timotej.snag/snag.db",
+            actual = path,
+        )
+    }
+}

--- a/lib/database/fe/src/webMain/kotlin/cz/adamec/timotej/snag/lib/database/fe/SqlDriverFactory.web.kt
+++ b/lib/database/fe/src/webMain/kotlin/cz/adamec/timotej/snag/lib/database/fe/SqlDriverFactory.web.kt
@@ -21,4 +21,5 @@ import org.koin.core.scope.Scope
 actual fun Scope.createPlatformSqlDriver(
     schema: SqlSchema<QueryResult.AsyncValue<Unit>>,
     name: String,
+    appId: String,
 ): SqlDriver = createDefaultWebWorkerDriver()

--- a/server/src/main/kotlin/cz/adamec/timotej/snag/impl/internal/DevDataSeederConfiguration.kt
+++ b/server/src/main/kotlin/cz/adamec/timotej/snag/impl/internal/DevDataSeederConfiguration.kt
@@ -432,8 +432,8 @@ internal class DevDataSeederConfiguration(
 
         private const val FLOOR_PLAN_URL_1 =
             "https://storage.googleapis.com/snag-bucket-dev/projects/" +
-                    "00000000-0000-0000-0000-000000000001/structures/" +
-                    "00000000-0000-0000-0001-000000000001/019dabac-f533-73d2-9f9d-27eadb7eed0c.png"
+                "00000000-0000-0000-0000-000000000001/structures/" +
+                "00000000-0000-0000-0001-000000000001/019dabac-f533-73d2-9f9d-27eadb7eed0c.png"
         private const val FLOOR_PLAN_URL_6 =
             "https://storage.googleapis.com/snag-bucket-dev/projects/" +
                 "00000000-0000-0000-0000-000000000001/structures/" +


### PR DESCRIPTION
## Problem Statement

Desktop release builds crashed on GUI launch (Finder / Start menu / file manager) on all three desktop platforms — macOS DMG, Windows MSI, Linux DEB. CLI launches usually opened, then crashed on the first network call.

Three independent ProGuard / jpackage issues stacked on top of each other:

1. **`FreshUsersInitializer` Koin error on GUI launch.** The driver was opened with a relative URL `jdbc:sqlite:snag.db`, resolved against the process `cwd`. Shell launches inherit `$HOME`; GUI launches set `cwd=/` (mac/linux) or `C:\Windows\System32` (win), so SQLite returned `SQLITE_CANTOPEN`. Koin surfaced the failure as the topmost factory in the dependency chain (`FreshUsersInitializer → ExecutePullSyncUseCase → ProjectPullSyncHandler → ProjectsDb → SnagDatabase → SqlDriver`), which made the message look like a Koin wiring bug.
2. **`java.lang.VerifyError: Bad return type` on first OkHttp TCP connect (CLI launch).** ProGuard's optimizer specialized `Okio.buffer(Sink): BufferedSink` into `Okio__OkioKt.buffer$43c083be(Sink): RealBufferedSink` whose declared return type no longer matched the actual stack value, triggering JVM bytecode verification.
3. **`NoClassDefFoundError: sun/misc/Unsafe` at login.** `datastore-preferences-protobuf` reflectively uses `sun.misc.Unsafe`, which lives in the `jdk.unsupported` module that the jpackage runtime image was excluding (only `java.sql` was declared).

## Solution

1. **JVM SqlDriverFactory uses an absolute, OS-appropriate per-app data dir.**
   - macOS: `~/Library/Application Support/<ns>`
   - Windows: `%APPDATA%\<ns>` (falls back to `~/AppData/Roaming/<ns>`)
   - Linux: `${XDG_DATA_HOME}/<ns>` (falls back to `~/.local/share/<ns>`)

   `appId` threaded through `expect`/`actual createPlatformSqlDriver` and `sqlDelightDatabaseModule`. Callers (`featShared/database/fe/driven/impl`, `feat/sync/fe/driven/impl`) pass `FrontendRunConfig.namespace`. Path resolution extracted into a pure helper `resolveJvmAppDatabasePath` for testability. Parent dirs are `mkdirs()`-ed before the JDBC connection opens.

2. **Pin okio/okhttp from ProGuard optimization** in `proguard-desktop.pro` to keep their bytecode signatures intact.

3. **Add `jdk.unsupported`** to the jpackage `modules()` list in `composeApp/build.gradle.kts`.

**Drive-by:** pre-existing ktlint indent violation in `DevDataSeederConfiguration.kt:435–436` (20 spaces, should be 16) fixed in the same pass per `CLAUDE.md`.

## Test Coverage

### Unit Tests

- `JvmAppDatabasePathTest` (new, 7 cases): macOS Application Support path, Windows with `APPDATA` set, Windows fallback when `APPDATA` missing, Linux with `XDG_DATA_HOME` set, Linux fallback when missing, unknown OS treated as Linux-like, blank `XDG_DATA_HOME` falls back to `.local/share`.
- `./gradlew check` green across all modules and platforms.

### Manual Testing

Reproduce a fresh GUI launch on each platform after building the release distribution; the test should show the app reaching the main / login screen without the dependency-injection crash.

- [x] **macOS DMG** — built via `:composeApp:packageReleaseDmg`, ran via `cd / && env -i HOME=$HOME PATH=/usr/bin:/bin USER=$USER <app>/Contents/MacOS/<bin>` (simulates Finder launch with `cwd=/` and minimal env)
  - Before: Koin `Could not create instance for factory ... FreshUsersInitializer`
  - After: app reaches `Starting webserver at port 8080, waiting for call on /auth-callback`; `~/Library/Application Support/cz.adamec.timotej.snag/{snag,sync}.db` created
- [ ] **Windows MSI** — install MSI, double-click the start-menu shortcut
  - Before: same Koin `FreshUsersInitializer` error
  - After: app opens, DBs land in `%APPDATA%\cz.adamec.timotej.snag\`
- [ ] **Linux DEB** — install DEB, launch from app menu
  - Before: same Koin `FreshUsersInitializer` error
  - After: app opens, DBs land in `~/.local/share/cz.adamec.timotej.snag/`

## References

n/a — no Jira ticket; tracked via in-session debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)