### PR TITLE
feat: refresh OIDC access token on 401

### DIFF
--- a/feat/authentication/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/authentication/fe/app/api/RefreshAccessTokenUseCase.kt
+++ b/feat/authentication/fe/app/api/src/commonMain/kotlin/cz/adamec/timotej/snag/authentication/fe/app/api/RefreshAccessTokenUseCase.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.authentication.fe.app.api
+
+fun interface RefreshAccessTokenUseCase {
+    suspend operator fun invoke(): String?
+}

--- a/feat/authentication/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/authentication/fe/app/impl/di/AuthenticationAppModule.kt
+++ b/feat/authentication/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/authentication/fe/app/impl/di/AuthenticationAppModule.kt
@@ -17,12 +17,14 @@ import cz.adamec.timotej.snag.authentication.fe.app.api.GetAuthProviderIdUseCase
 import cz.adamec.timotej.snag.authentication.fe.app.api.IsCurrentUserAuthenticatedFlowUseCase
 import cz.adamec.timotej.snag.authentication.fe.app.api.LoginUseCase
 import cz.adamec.timotej.snag.authentication.fe.app.api.LogoutUseCase
+import cz.adamec.timotej.snag.authentication.fe.app.api.RefreshAccessTokenUseCase
 import cz.adamec.timotej.snag.authentication.fe.app.api.RestoreSessionUseCase
 import cz.adamec.timotej.snag.authentication.fe.app.impl.internal.GetAccessTokenUseCaseImpl
 import cz.adamec.timotej.snag.authentication.fe.app.impl.internal.GetAuthProviderIdUseCaseImpl
 import cz.adamec.timotej.snag.authentication.fe.app.impl.internal.IsCurrentUserAuthenticatedFlowUseCaseImpl
 import cz.adamec.timotej.snag.authentication.fe.app.impl.internal.LoginUseCaseImpl
 import cz.adamec.timotej.snag.authentication.fe.app.impl.internal.LogoutUseCaseImpl
+import cz.adamec.timotej.snag.authentication.fe.app.impl.internal.RefreshAccessTokenUseCaseImpl
 import cz.adamec.timotej.snag.authentication.fe.app.impl.internal.RestoreSessionUseCaseImpl
 import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.bind
@@ -32,6 +34,7 @@ val authenticationAppModule =
     module {
         factoryOf(::GetAuthProviderIdUseCaseImpl) bind GetAuthProviderIdUseCase::class
         factoryOf(::GetAccessTokenUseCaseImpl) bind GetAccessTokenUseCase::class
+        factoryOf(::RefreshAccessTokenUseCaseImpl) bind RefreshAccessTokenUseCase::class
         factoryOf(::LoginUseCaseImpl) bind LoginUseCase::class
         factoryOf(::LogoutUseCaseImpl) bind LogoutUseCase::class
         factoryOf(::RestoreSessionUseCaseImpl) bind RestoreSessionUseCase::class

--- a/feat/authentication/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/authentication/fe/app/impl/internal/RefreshAccessTokenUseCaseImpl.kt
+++ b/feat/authentication/fe/app/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/authentication/fe/app/impl/internal/RefreshAccessTokenUseCaseImpl.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.authentication.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.authentication.fe.app.api.RefreshAccessTokenUseCase
+import cz.adamec.timotej.snag.authentication.fe.app.impl.internal.LH.logger
+import cz.adamec.timotej.snag.authentication.fe.ports.AuthTokenProvider
+import cz.adamec.timotej.snag.core.foundation.common.runCatchingCancellable
+
+internal class RefreshAccessTokenUseCaseImpl(
+    private val authTokenProvider: AuthTokenProvider,
+) : RefreshAccessTokenUseCase {
+    override suspend fun invoke(): String? {
+        logger.d { "Executing access token refresh." }
+        return runCatchingCancellable {
+            authTokenProvider.refreshAccessToken()
+        }.getOrElse { e ->
+            logger.e(throwable = e) { "Access token refresh failed, logging out." }
+            authTokenProvider.logout()
+            null
+        }
+    }
+}

--- a/feat/authentication/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/authentication/fe/app/impl/internal/RefreshAccessTokenUseCaseImplTest.kt
+++ b/feat/authentication/fe/app/impl/src/commonTest/kotlin/cz/adamec/timotej/snag/authentication/fe/app/impl/internal/RefreshAccessTokenUseCaseImplTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Timotej Adamec
+ * SPDX-License-Identifier: MIT
+ *
+ * This file is part of the thesis:
+ * "Multiplatform snagging system with code sharing maximisation"
+ *
+ * Czech Technical University in Prague
+ * Faculty of Information Technology
+ * Department of Software Engineering
+ */
+
+package cz.adamec.timotej.snag.authentication.fe.app.impl.internal
+
+import cz.adamec.timotej.snag.authentication.fe.driven.test.FakeAuthTokenProvider
+import cz.adamec.timotej.snag.authentication.fe.ports.AuthState
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+class RefreshAccessTokenUseCaseImplTest {
+    @Test
+    fun `returns refreshed token from provider`() =
+        runTest {
+            val provider = FakeAuthTokenProvider()
+            val useCase = RefreshAccessTokenUseCaseImpl(authTokenProvider = provider)
+
+            assertEquals(expected = "fake-access-token", actual = useCase())
+        }
+
+    @Test
+    fun `triggers logout and returns null on provider failure`() =
+        runTest {
+            val provider = FakeAuthTokenProvider()
+            provider.refreshFailure = IllegalStateException("Refresh failed")
+            val useCase = RefreshAccessTokenUseCaseImpl(authTokenProvider = provider)
+
+            val result = useCase()
+
+            assertNull(actual = result)
+            assertIs<AuthState.Unauthenticated>(provider.authState.value)
+        }
+}

--- a/feat/authentication/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/authentication/fe/driven/di/AuthenticationDrivenModule.kt
+++ b/feat/authentication/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/authentication/fe/driven/di/AuthenticationDrivenModule.kt
@@ -19,20 +19,25 @@ import cz.adamec.timotej.snag.configuration.common.RunConfig
 import org.koin.core.module.Module
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
+import org.publicvalue.multiplatform.oidc.ExperimentalOpenIdConnect
+import org.publicvalue.multiplatform.oidc.tokenstore.TokenRefreshHandler
 
 internal val OIDC_REDIRECT_URI_QUALIFIER = named("oidcRedirectUri")
 
 internal expect val platformModule: Module
 
+@OptIn(ExperimentalOpenIdConnect::class)
 val authenticationDrivenModule =
     module {
         includes(platformModule)
+        single { TokenRefreshHandler(tokenStore = get()) }
         single<AuthTokenProvider> {
             if (RunConfig.mockAuth) {
                 MockAuthTokenProvider()
             } else {
                 OidcAuthTokenProvider(
                     tokenStore = get(),
+                    tokenRefreshHandler = get(),
                     authFlowFactory = get(),
                     redirectUri = get(qualifier = OIDC_REDIRECT_URI_QUALIFIER),
                 )

--- a/feat/authentication/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/authentication/fe/driven/internal/MockAuthTokenProvider.kt
+++ b/feat/authentication/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/authentication/fe/driven/internal/MockAuthTokenProvider.kt
@@ -39,6 +39,11 @@ internal class MockAuthTokenProvider : AuthTokenProvider {
         return MOCK_USER_ID
     }
 
+    override suspend fun refreshAccessToken(): String? {
+        logger.d { "Mock: returning mock user ID as refreshed access token." }
+        return MOCK_USER_ID
+    }
+
     override suspend fun logout() {
         logger.d { "Mock: logging out." }
         _authState.value = AuthState.Unauthenticated

--- a/feat/authentication/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/authentication/fe/driven/internal/OidcAuthTokenProvider.kt
+++ b/feat/authentication/fe/driven/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/authentication/fe/driven/internal/OidcAuthTokenProvider.kt
@@ -20,12 +20,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.publicvalue.multiplatform.oidc.OpenIdConnectClient
 import org.publicvalue.multiplatform.oidc.flows.CodeAuthFlowFactory
+import org.publicvalue.multiplatform.oidc.tokenstore.TokenRefreshHandler
 import org.publicvalue.multiplatform.oidc.tokenstore.TokenStore
 import org.publicvalue.multiplatform.oidc.types.CodeChallengeMethod
 import org.publicvalue.multiplatform.oidc.types.Jwt
 
 internal class OidcAuthTokenProvider(
     private val tokenStore: TokenStore,
+    private val tokenRefreshHandler: TokenRefreshHandler,
     private val authFlowFactory: CodeAuthFlowFactory,
     redirectUri: String,
 ) : AuthTokenProvider {
@@ -87,6 +89,24 @@ internal class OidcAuthTokenProvider(
         return tokenStore.getAccessToken().also {
             logger.d { "Got access token: present=${it != null}." }
         }
+    }
+
+    override suspend fun refreshAccessToken(): String? {
+        logger.d { "Refreshing access token." }
+        val storedRefreshToken = tokenStore.getRefreshToken()
+        if (storedRefreshToken.isNullOrBlank()) {
+            logger.d { "No stored refresh token, cannot refresh." }
+            _authState.value = AuthState.Unauthenticated
+            return null
+        }
+        val oldAccessToken = tokenStore.getAccessToken().orEmpty()
+        val newTokens =
+            tokenRefreshHandler.refreshAndSaveToken(
+                client = client,
+                oldAccessToken = oldAccessToken,
+            )
+        logger.d { "Access token refreshed." }
+        return newTokens.accessToken
     }
 
     override suspend fun logout() {

--- a/feat/authentication/fe/driven/test/src/commonMain/kotlin/cz/adamec/timotej/snag/authentication/fe/driven/test/FakeAuthTokenProvider.kt
+++ b/feat/authentication/fe/driven/test/src/commonMain/kotlin/cz/adamec/timotej/snag/authentication/fe/driven/test/FakeAuthTokenProvider.kt
@@ -24,6 +24,7 @@ class FakeAuthTokenProvider(
     override val authState: StateFlow<AuthState> = _authState
 
     var loginFailure: Throwable? = null
+    var refreshFailure: Throwable? = null
 
     override suspend fun restoreSession() = Unit
 
@@ -33,6 +34,11 @@ class FakeAuthTokenProvider(
     }
 
     override suspend fun getAccessToken(): String? = "fake-access-token"
+
+    override suspend fun refreshAccessToken(): String? {
+        refreshFailure?.let { throw it }
+        return "fake-access-token"
+    }
 
     override suspend fun logout() {
         _authState.value = AuthState.Unauthenticated

--- a/feat/authentication/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/authentication/fe/driving/impl/internal/CurrentUserKtorClientConfiguration.kt
+++ b/feat/authentication/fe/driving/impl/src/commonMain/kotlin/cz/adamec/timotej/snag/authentication/fe/driving/impl/internal/CurrentUserKtorClientConfiguration.kt
@@ -13,6 +13,7 @@
 package cz.adamec.timotej.snag.authentication.fe.driving.impl.internal
 
 import cz.adamec.timotej.snag.authentication.fe.app.api.GetAccessTokenUseCase
+import cz.adamec.timotej.snag.authentication.fe.app.api.RefreshAccessTokenUseCase
 import cz.adamec.timotej.snag.configuration.common.RunConfig
 import cz.adamec.timotej.snag.network.fe.ports.KtorClientConfiguration
 import cz.adamec.timotej.snag.routing.common.USER_ID_HEADER
@@ -25,6 +26,7 @@ import io.ktor.client.plugins.auth.providers.bearer
 @Suppress("LabeledExpression")
 internal class CurrentUserKtorClientConfiguration(
     private val getAccessTokenUseCase: GetAccessTokenUseCase,
+    private val refreshAccessTokenUseCase: RefreshAccessTokenUseCase,
 ) : KtorClientConfiguration {
     override fun HttpClientConfig<*>.setup() {
         if (RunConfig.mockAuth) {
@@ -50,6 +52,10 @@ internal class CurrentUserKtorClientConfiguration(
             bearer {
                 loadTokens {
                     getAccessTokenUseCase()
+                        ?.let { BearerTokens(accessToken = it, refreshToken = "") }
+                }
+                refreshTokens {
+                    refreshAccessTokenUseCase()
                         ?.let { BearerTokens(accessToken = it, refreshToken = "") }
                 }
                 sendWithoutRequest { true }

--- a/feat/authentication/fe/ports/src/commonMain/kotlin/cz/adamec/timotej/snag/authentication/fe/ports/AuthTokenProvider.kt
+++ b/feat/authentication/fe/ports/src/commonMain/kotlin/cz/adamec/timotej/snag/authentication/fe/ports/AuthTokenProvider.kt
@@ -23,5 +23,7 @@ interface AuthTokenProvider {
 
     suspend fun getAccessToken(): String?
 
+    suspend fun refreshAccessToken(): String?
+
     suspend fun logout()
 }


### PR DESCRIPTION
## Problem Statement

`feat/authentication` stored the OIDC `refresh_token` on login but never used it. `OidcAuthTokenProvider.getAccessToken()` returned the stored access token verbatim, and `CurrentUserKtorClientConfiguration` configured Ktor `bearer { loadTokens { ... } }` only — no `refreshTokens { }` block. Once the access token expired (Entra ID default ~1h) the backend returned 401 and the user had to manually log out / log in again.

## Solution

Extend the `AuthTokenProvider` port with `refreshAccessToken(): String?`, exposed via a new `RefreshAccessTokenUseCase`, and call it from a `bearer { refreshTokens { } }` block. OIDC infrastructure stays encapsulated in `driven/impl`; the driving layer talks to use cases only — matches the existing `GetAccessTokenUseCase` shape and avoids leaking `OpenIdConnectClient` / `TokenStore` upward.

Inside `OidcAuthTokenProvider` the refresh delegates to the library's `TokenRefreshHandler.refreshAndSaveToken(client, oldAccessToken)`:
- internal `Mutex` serialises concurrent refreshes — parallel calls hitting 401 simultaneously coalesce into a single network refresh
- double-check against `oldAccessToken` returns already-refreshed tokens if another caller refreshed while we waited on the mutex
- preserves the previous `refresh_token` when the response omits one (Entra ID rolling-refresh nuance)
- registered as a process-singleton in Koin

On unrecoverable failure the use case calls `logout()`, clearing the token store and flipping `AuthState` to `Unauthenticated`. Ktor's next `loadTokens` returns `null`, the next request hits the auth gate.

When there is no stored refresh token at all (already-unauthenticated state), the provider short-circuits with `null` and sets `Unauthenticated` directly — that is a state transition, not error translation, so it stays in the provider per the project's auth-catching pattern.

## Test Coverage

### Unit Tests
- `RefreshAccessTokenUseCaseImplTest`
  - `returns refreshed token from provider` — success path delegates and returns the access token
  - `triggers logout and returns null on provider failure` — `refreshFailure = IllegalStateException`, asserts use case returns `null` and `authState` ends `Unauthenticated`
- `FakeAuthTokenProvider` — added `refreshAccessToken()` + `refreshFailure: Throwable?` knob (mirrors existing `loginFailure`)

`OidcAuthTokenProvider.refreshAccessToken()` itself is not unit-tested — would require mocking `OpenIdConnectClient`; no existing tests for the provider, out of scope.
`CurrentUserKtorClientConfiguration` — no existing tests in its neighborhood.

### Manual Testing
- [ ] Log in → close + reopen app → session restored (regression check, already worked)
- [ ] Authenticated request after access-token expiry → silent refresh, request succeeds with new token; logs show `Refreshing access token` → `Access token refreshed`
- [ ] Refresh token revoked tenant-side → next authenticated call → `Access token refresh failed, logging out.` → `AuthState.Unauthenticated` → auth gate shown

## Out of scope / deferred

- `ktorHttpClient.clearTokens()` on logout — to verify during manual QA
- End-session call to Entra ID on logout
- Pre-emptive refresh based on `expires_in`

## References

Snag tracks issues on GitHub, no Jira ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)