### PR TITLE
docs: correct server target config + tags link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ git tag fe-v1.2.0   # or be-v1.2.0
 git push origin fe-v1.2.0
 ```
 
-All release tags are listed on the [Tags](https://github.com/timotejAdamec/Snag/tags) page. Frontend tags trigger GitHub Actions to build downloadable artifacts and publish a GitHub Release. Backend tags trigger a deployment workflow that builds a Docker image, pushes it to Artifact Registry, and rolls out the `snag-server-demo` service on GCP Cloud Run (region `europe-west3`); no GitHub artifacts are published.
+All release tags are listed on the [Tags](https://github.com/timotejAdamec/Snag/tags) page. Frontend tags trigger GitHub Actions to build downloadable artifacts and publish a GitHub Release. Backend tags trigger a deployment workflow that builds a Docker image, pushes it to GCP Artifact Registry, and rolls out the `snag-server-demo` service on GCP Cloud Run (region `europe-west3`); no GitHub artifacts are published.
 
 ## Project structure
 

--- a/README.md
+++ b/README.md
@@ -98,15 +98,15 @@ The script loads `config/common-debug.properties` and `config/backend-debug.env`
 
 ## Choosing a server target
 
-Frontend clients default to `localhost`. To target a Cloud Run deployment instead, set `snag.serverTarget` in `gradle.properties`:
+Frontend debug builds default to `localhost`; release builds default to `demo`. To override the debug default, edit `snag.serverTarget` in [`config/frontend-debug.properties`](./config/frontend-debug.properties):
 
 ```properties
 snag.serverTarget=dev
 ```
 
-Valid values: `localhost` (default), `dev`, `demo`. Re-sync Gradle in your IDE after changing it. Applies to all frontend targets (Android, desktop, web, iOS).
+Valid values: `localhost`, `dev`, `demo`. Re-sync Gradle in your IDE after changing it. Applies to all frontend targets (Android, desktop, web, iOS). The release default lives in [`config/frontend-release.properties`](./config/frontend-release.properties).
 
-You can also pass it per-invocation without editing any files:
+You can also override per-invocation without editing any files:
 
 ```shell
 ./gradlew <task> -Psnag.serverTarget=dev
@@ -126,7 +126,7 @@ git tag fe-v1.2.0   # or be-v1.2.0
 git push origin fe-v1.2.0
 ```
 
-GitHub Actions then builds the matching artifacts and publishes a GitHub Release. Downloads live on the [Releases](https://github.com/timotejAdamec/Snag/releases) page.
+All release tags are listed on the [Tags](https://github.com/timotejAdamec/Snag/tags) page. Frontend tags trigger GitHub Actions to build downloadable artifacts and publish a GitHub Release. Backend tags trigger a deployment workflow that builds a Docker image, pushes it to Artifact Registry, and rolls out the `snag-server-demo` service on GCP Cloud Run (region `europe-west3`); no GitHub artifacts are published.
 
 ## Project structure
 


### PR DESCRIPTION
## Problem Statement

The README's "Choosing a server target" section pointed users at root `gradle.properties`, but the canonical defaults live in `config/frontend-debug.properties` (debug → `localhost`) and `config/frontend-release.properties` (release → `demo`). The "default `localhost`" claim only holds for debug builds. The "Releases" section linked to `/releases`, which hides backend tags entirely (the BE deploy workflow does not publish a GitHub Release; it ships a Cloud Run rollout).

## Solution

- Point the server-target instructions at `config/frontend-debug.properties`, note the release-side default, and link the release config too.
- Swap the `/releases` link for `/tags` and describe what each tag prefix actually triggers: `fe-v*` → GitHub Release with artifacts; `be-v*` → Docker build + Artifact Registry push + Cloud Run rollout (`snag-server-demo`, `europe-west3`).

## Test Coverage

Docs-only change.

### Manual Testing

- [ ] Open README, follow the server-target link to `config/frontend-debug.properties` and confirm `snag.serverTarget=localhost` is the line referenced.
- [ ] Follow the Tags link and confirm both `fe-v*` and `be-v*` tags appear.

## References

N/A — README cleanup, no ticket.