### PR TITLE
chore: gate fe network logging via build profile log level

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -47,6 +47,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(projects.koinModulesAggregate.fe)
+            implementation(projects.lib.configuration.fe.api)
             implementation(projects.lib.design.fe.api)
             implementation(projects.feat.authentication.fe.driving.api)
             implementation(projects.feat.sync.fe.app.api)

--- a/composeApp/src/commonMain/kotlin/cz/adamec/timotej/snag/logging/LoggerModule.kt
+++ b/composeApp/src/commonMain/kotlin/cz/adamec/timotej/snag/logging/LoggerModule.kt
@@ -13,10 +13,13 @@
 package cz.adamec.timotej.snag.logging
 
 import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
 import co.touchlab.kermit.platformLogWriter
+import cz.adamec.timotej.snag.configuration.fe.FrontendRunConfig
 import org.koin.dsl.module
 
 internal val loggerModule =
     module {
         Logger.setLogWriters(platformLogWriter())
+        Logger.setMinSeverity(Severity.valueOf(FrontendRunConfig.logLevel))
     }

--- a/config/frontend-debug.properties
+++ b/config/frontend-debug.properties
@@ -14,6 +14,8 @@ snag.serverTarget=localhost
 snag.serverLocalhostPort=8081
 snag.serverDevUrl=https://snag-server-dev-ioifzecczq-ey.a.run.app
 snag.serverDemoUrl=https://snag-server-demo-ioifzecczq-ey.a.run.app
+# Kermit Severity name (Verbose, Debug, Info, Warn, Error, Assert).
+snag.logLevel=Verbose
 # Platform-specific redirect URIs (MobileRunConfig, JvmRunConfig, WebRunConfig)
 snag.entraIdMobileRedirectUri=snag://auth-callback
 snag.entraIdJvmRedirectUri=http://localhost:8080/auth-callback

--- a/config/frontend-debug.properties
+++ b/config/frontend-debug.properties
@@ -14,7 +14,7 @@ snag.serverTarget=localhost
 snag.serverLocalhostPort=8081
 snag.serverDevUrl=https://snag-server-dev-ioifzecczq-ey.a.run.app
 snag.serverDemoUrl=https://snag-server-demo-ioifzecczq-ey.a.run.app
-# Kermit Severity name (Verbose, Debug, Info, Warn, Error, Assert).
+# Options: Verbose, Debug, Info, Warn, Error, Assert
 snag.logLevel=Verbose
 # Platform-specific redirect URIs (MobileRunConfig, JvmRunConfig, WebRunConfig)
 snag.entraIdMobileRedirectUri=snag://auth-callback

--- a/config/frontend-release.properties
+++ b/config/frontend-release.properties
@@ -14,6 +14,10 @@ snag.serverTarget=demo
 snag.serverLocalhostPort=8081
 snag.serverDevUrl=https://snag-server-dev-ioifzecczq-ey.a.run.app
 snag.serverDemoUrl=https://snag-server-demo-ioifzecczq-ey.a.run.app
+# Kermit Severity name (Verbose, Debug, Info, Warn, Error, Assert).
+# Info or higher drops the Ktor HTTP Client logger (writes at Verbose), preventing
+# request URLs/headers from leaking into platform logs in release builds.
+snag.logLevel=Info
 # Platform-specific redirect URIs (MobileRunConfig, JvmRunConfig, WebRunConfig)
 snag.entraIdMobileRedirectUri=snag://auth-callback
 snag.entraIdJvmRedirectUri=http://localhost:8080/auth-callback

--- a/config/frontend-release.properties
+++ b/config/frontend-release.properties
@@ -14,9 +14,6 @@ snag.serverTarget=demo
 snag.serverLocalhostPort=8081
 snag.serverDevUrl=https://snag-server-dev-ioifzecczq-ey.a.run.app
 snag.serverDemoUrl=https://snag-server-demo-ioifzecczq-ey.a.run.app
-# Kermit Severity name (Verbose, Debug, Info, Warn, Error, Assert).
-# Info or higher drops the Ktor HTTP Client logger (writes at Verbose), preventing
-# request URLs/headers from leaking into platform logs in release builds.
 snag.logLevel=Info
 # Platform-specific redirect URIs (MobileRunConfig, JvmRunConfig, WebRunConfig)
 snag.entraIdMobileRedirectUri=snag://auth-callback

--- a/lib/configuration/fe/api/build.gradle.kts
+++ b/lib/configuration/fe/api/build.gradle.kts
@@ -56,6 +56,7 @@ val serverTarget = requireProperty("snag.serverTarget")
 val serverLocalhostPort = requireProperty("snag.serverLocalhostPort")
 val serverDevUrl = requireProperty("snag.serverDevUrl")
 val serverDemoUrl = requireProperty("snag.serverDemoUrl")
+val logLevel = requireProperty("snag.logLevel")
 val entraIdMobileRedirectUri = requireProperty("snag.entraIdMobileRedirectUri")
 val entraIdJvmRedirectUri = requireProperty("snag.entraIdJvmRedirectUri")
 val entraIdWebRedirectPath = requireProperty("snag.entraIdWebRedirectPath")
@@ -87,6 +88,12 @@ buildkonfig {
             com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING,
             "SERVER_DEMO_URL",
             serverDemoUrl,
+            const = true,
+        )
+        buildConfigField(
+            com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING,
+            "LOG_LEVEL",
+            logLevel,
             const = true,
         )
         buildConfigField(

--- a/lib/configuration/fe/api/src/commonMain/kotlin/cz/adamec/timotej/snag/configuration/fe/FrontendRunConfig.kt
+++ b/lib/configuration/fe/api/src/commonMain/kotlin/cz/adamec/timotej/snag/configuration/fe/FrontendRunConfig.kt
@@ -19,11 +19,5 @@ package cz.adamec.timotej.snag.configuration.fe
  */
 object FrontendRunConfig {
     val serverTarget: ServerTarget = ServerTarget.fromBuildConfig()
-
-    /**
-     * Kermit `Severity` name (e.g. `Verbose`, `Debug`, `Info`). The application initialises
-     * the global Kermit logger at this minimum severity, which gates all platform log output —
-     * including the Ktor `HTTP Client` logger that writes at `Verbose`.
-     */
     val logLevel: String = FrontendBuildConfig.LOG_LEVEL
 }

--- a/lib/configuration/fe/api/src/commonMain/kotlin/cz/adamec/timotej/snag/configuration/fe/FrontendRunConfig.kt
+++ b/lib/configuration/fe/api/src/commonMain/kotlin/cz/adamec/timotej/snag/configuration/fe/FrontendRunConfig.kt
@@ -19,4 +19,11 @@ package cz.adamec.timotej.snag.configuration.fe
  */
 object FrontendRunConfig {
     val serverTarget: ServerTarget = ServerTarget.fromBuildConfig()
+
+    /**
+     * Kermit `Severity` name (e.g. `Verbose`, `Debug`, `Info`). The application initialises
+     * the global Kermit logger at this minimum severity, which gates all platform log output —
+     * including the Ktor `HTTP Client` logger that writes at `Verbose`.
+     */
+    val logLevel: String = FrontendBuildConfig.LOG_LEVEL
 }


### PR DESCRIPTION
## Problem Statement

The Ktor `Logging` plugin on the frontend (`lib/network/fe/impl/.../LoggingConfiguration.kt`) is installed unconditionally at `LogLevel.HEADERS` and writes through Kermit at `Verbose`. In any release build that means every HTTP request emits its URL and all non-`Authorization` headers to logcat (Android) / browser console (web) / native console (iOS, JVM). Even though the bearer token itself is masked via `sanitizeHeader`, this gives any process with log-read access (e.g. another debuggable app on Android, any third-party script on the web page) a continuous stream of API endpoint metadata.

There was no knob for this — debug and release behaved identically.

## Solution

Mirror the pattern used for the backend (`SNAG_LOG_LEVEL` on `BackendRunConfig`) for the frontend. Introduce `snag.logLevel` in `config/frontend-{debug,release}.properties`, push it through BuildKonfig as `FrontendBuildConfig.LOG_LEVEL`, and expose it as `FrontendRunConfig.logLevel`. At app start, `LoggerModule` parses it into a Kermit `Severity` and calls `Logger.setMinSeverity(...)`.

Profiles ship with:
- debug: `Verbose` — current behaviour preserved; HTTP traffic stays inspectable.
- release: `Info` — drops the Ktor `HTTP Client` lines (which write at `Verbose`) and the rest of the app's `logger.d {...}` noise before any of it reaches a log writer.

The fix uses the existing log layer; nothing changes in `LoggingConfiguration` itself, so the option to inspect HTTP traffic in debug remains and there's a single dial controlling it.

## Test Coverage

### Unit Tests

The change is glue code (config field + `Logger.setMinSeverity(Severity.valueOf(...))`); no new logic to unit-test directly. The existing `composeApp/jvmTest/.../AppModuleTest.checkKoinModule` exercises the path: it loads `appModule`, which includes `loggerModule`, which evaluates `Severity.valueOf(FrontendRunConfig.logLevel)` at module construction. An invalid profile value would surface there.

### Manual Testing

- [ ] Run a debug build, perform any authenticated request, confirm `HTTP Client` log lines with the request URL and headers still appear in the platform log.
- [ ] Run a release build, perform the same request, confirm no `HTTP Client` log lines are emitted.
- [ ] Confirm `logger.d {...}` calls in auth use cases are dropped in release but visible in debug.

## References

- Network logging review identified the unconditional `LogLevel.HEADERS` install as the highest-priority finding in this audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)